### PR TITLE
WIP: Better Rotation Logic & Collision Detection

### DIFF
--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -309,6 +309,23 @@ function New-WordCloud {
         $FontStyle = [FontStyle]::Regular,
 
         [Parameter()]
+        [Alias('StrokeColour')]
+        [ArgumentCompleter(
+            {
+                param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
+                if (!$WordToComplete) {
+                    return [ColorTransformAttribute]::ColorNames
+                }
+                else {
+                    return [ColorTransformAttribute]::ColorNames.Where{ $_.StartsWith($WordToComplete) }
+                }
+            }
+        )]
+        [ColorTransformAttribute()]
+        [Color]
+        $StrokeColor = [Color]::Black,
+
+        [Parameter()]
         [Alias('Outline')]
         [double]
         $StrokeWidth,
@@ -521,7 +538,7 @@ function New-WordCloud {
             $MaxSideLength = [Math]::Max($WordCloudImage.Width, $WordCloudImage.Height)
             $FontScale = 1.5 * ($WordCloudImage.Height + $WordCloudImage.Width) / ($AverageFrequency * $SortedWordList.Count)
             $DrawingSurface.SmoothingMode = [Drawing2D.SmoothingMode]::AntiAlias
-            $DrawingSurface.TextRenderingHint = [Text.TextRenderingHint]::AntiAlias
+            $DrawingSurface.TextRenderingHint = [Text.TextRenderingHint]::ClearTypeGridFit
 
             :size do {
                 foreach ($Word in $SortedWordList) {
@@ -610,7 +627,7 @@ function New-WordCloud {
                 if (-not $WordSizeTable[$Word]) { continue }
                 if ($StrokeWidth) {
                     $StrokePen = [Pen]::new(
-                        [SolidBrush]::new([Color]::Black),
+                        [SolidBrush]::new($StrokeColor),
                         $StrokeWidth * $WordHeightTable[$Word].Height / 0.1
                     )
                 }
@@ -774,9 +791,7 @@ function New-WordCloud {
                     # No available free space anywhere in this radial scan, keep scanning
                     $RadialDistance += $RNG.NextDouble() * ($Bounds.Width + $Bounds.Height) * $DistanceStep / 20
                 } while ($WordIntersects)
-
-            if ($WordIntersects) { continue words }
-
+            }
             # All words written that we can
             $DrawingSurface.Flush()
 

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -440,6 +440,7 @@ function New-WordCloud {
         $SplitChars = " `n.,`"?!{}[]:()`“`”™*#%^&+=" -as [char[]]
         $ColorIndex = 0
         $RadialDistance = 0
+        $GraphicsUnit = [GraphicsUnit]::Display
 
         $WordList = [List[string]]::new()
         $WordHeightTable = @{}
@@ -548,7 +549,7 @@ function New-WordCloud {
             }
 
             $DrawingSurface.PageScale = 1.0
-            $DrawingSurface.PageUnit = [GraphicsUnit]::Pixel
+            $DrawingSurface.PageUnit = $GraphicsUnit
             $DrawingSurface.SmoothingMode = [Drawing2D.SmoothingMode]::AntiAlias
             $DrawingSurface.TextRenderingHint = [Text.TextRenderingHint]::ClearTypeGridFit
 
@@ -571,7 +572,7 @@ function New-WordCloud {
                         $FontFamily,
                         $WordHeightTable[$Word],
                         $FontStyle,
-                        [GraphicsUnit]::Pixel
+                        $GraphicsUnit
                     )
 
                     [SizeF] $WordSize = $DrawingSurface.MeasureString($Word, $Font)

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -770,28 +770,7 @@ function New-WordCloud {
                     $RadialDistance += $RNG.NextDouble() * ($Bounds.Width + $Bounds.Height) * $DistanceStep / 20
                 } while ($WordIntersects)
 
-                if ($WordIntersects) { continue words }
-
-                <#
-                    $RotateFormat = [StringFormat]::new([StringFormatFlags]::DirectionVertical)
-                    $DrawingSurface.DrawString($Word, $Font, $Brush, $DrawLocation, $RotateFormat)
-
-                }
-                else {
-                    $FormatString -f @(
-                        "'$Word'"
-                        $Color.R
-                        $Color.G
-                        $Color.B
-                        $Color.A
-                        "$($Font.SizeInPoints) pt"
-                        $DrawLocation.ToString()
-                        'Horizontal'
-                    ) | Write-Verbose
-                    $DrawingSurface.DrawString($Word, $Font, $Brush, $DrawLocation)
-                }
-#>
-            }
+            if ($WordIntersects) { continue words }
 
             # All words written that we can
             $DrawingSurface.Flush()

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -398,7 +398,7 @@ function New-WordCloud {
 
         [Parameter()]
         [Alias('MaxWords')]
-        [ValidateRange(10, 500)]
+        [ValidateRange(0, 1000)]
         [int]
         $MaxUniqueWords = 100,
 

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -87,8 +87,12 @@ class ColorTransformAttribute : ArgumentTransformationAttribute {
                     [Color]::FromArgb($Matches['Alpha'], $Matches['Red'], $Matches['Green'], $Matches['Blue'])
                     continue
                 }
+
+                if ($MatchingValues = [KnownColor].GetEnumNames() -like $_) {
+                    ($MatchingValues -as [KnownColor[]]).ForEach{ [Color]::FromKnownColor($_) }
+                }
             }
-            { $- -is [int] } {
+            { $_ -is [int] } {
                 [Color]::FromArgb($_)
                 continue
             }

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -774,8 +774,9 @@ function New-WordCloud {
 
                                 $ProgressParams = @{
                                     Activity         = "Testing draw location"
-                                    CurrentOperation = "Checking for sufficient space to draw at {0}" -f @(
+                                    CurrentOperation = "Checking for sufficient space to draw at {0} {1}" -f @(
                                         $DrawLocation
+                                        @('Vertically', 'Horizontally')[$Format -ne [StringFormatFlags]::DirectionVertical]
                                     )
                                     ParentId         = $ProgressID
                                     Id               = $ProgressID + 1

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -308,6 +308,11 @@ function New-WordCloud {
         [FontStyle]
         $FontStyle = [FontStyle]::Regular,
 
+        [Parameter()]
+        [Alias('Outline')]
+        [double]
+        $StrokeWidth,
+
         [Parameter(ParameterSetName = 'ColorBackground')]
         [Parameter(ParameterSetName = 'ColorBackground-Mono')]
         [Alias('ImagePixelSize')]
@@ -505,15 +510,12 @@ function New-WordCloud {
             if ($BackgroundImage.FullName) {
                 $WordCloudImage = [Bitmap]::new($BackgroundImage.FullName)
                 $DrawingSurface = [Graphics]::FromImage($WordCloudImage)
-
-                $StrokeBrush = [SolidBrush]::new([Color]::Black)
             }
             else {
                 $WordCloudImage = [Bitmap]::new($ImageSize.Width, $ImageSize.Height)
                 $DrawingSurface = [Graphics]::FromImage($WordCloudImage)
 
                 $DrawingSurface.Clear($BackgroundColor)
-                $Stroke = $null
             }
 
             $MaxSideLength = [Math]::Max($WordCloudImage.Width, $WordCloudImage.Height)
@@ -606,8 +608,11 @@ function New-WordCloud {
             Write-Verbose "$("-" * 21)+$("-" * 25)+$("-" * 12)+$("-" * 28)+$("-" * 11)"
             :words foreach ($Word in $SortedWordList) {
                 if (-not $WordSizeTable[$Word]) { continue }
-                if ($StrokeBrush) {
-                    $Stroke = [Pen]::new($StrokeBrush, $WordHeightTable[$Word].Height / 0.05)
+                if ($StrokeWidth) {
+                    $StrokePen = [Pen]::new(
+                        [SolidBrush]::new([Color]::Black),
+                        $StrokeWidth * $WordHeightTable[$Word].Height / 0.1
+                    )
                 }
 
                 $RadialDistance = 0
@@ -744,8 +749,8 @@ function New-WordCloud {
                                     ) | Write-Verbose
 
                                     $DrawingSurface.FillPath($Brush, $WordPath)
-                                    if ($Stroke) {
-                                        $DrawingSurface.DrawPath($Stroke, $WordPath)
+                                    if ($StrokePen) {
+                                        $DrawingSurface.DrawPath($StrokePen, $WordPath)
                                     }
 
                                     if ($BlankCanvas) {

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -525,8 +525,8 @@ function New-WordCloud {
 
         try {
             if ($BackgroundImage.FullName) {
-                $WordCloudImage = [Bitmap]::new($BackgroundImage.FullName)
-                $DrawingSurface = [Graphics]::FromImage($WordCloudImage)
+                [Image] $WordCloudImage = [Bitmap]::new($BackgroundImage.FullName)
+                [Graphics] $DrawingSurface = [Graphics]::FromImage($WordCloudImage)
             }
             else {
                 $WordCloudImage = [Bitmap]::new($ImageSize.Width, $ImageSize.Height)
@@ -535,10 +535,13 @@ function New-WordCloud {
                 $DrawingSurface.Clear($BackgroundColor)
             }
 
-            $MaxSideLength = [Math]::Max($WordCloudImage.Width, $WordCloudImage.Height)
-            $FontScale = 1.5 * ($WordCloudImage.Height + $WordCloudImage.Width) / ($AverageFrequency * $SortedWordList.Count)
+            $DrawingSurface.PageScale = 1.0
+            $DrawingSurface.GraphicsUnit = [GraphicsUnit]::Pixel
             $DrawingSurface.SmoothingMode = [Drawing2D.SmoothingMode]::AntiAlias
             $DrawingSurface.TextRenderingHint = [Text.TextRenderingHint]::ClearTypeGridFit
+
+            $MaxSideLength = [Math]::Max($WordCloudImage.Width, $WordCloudImage.Height)
+            $FontScale = 1.5 * ($WordCloudImage.Height + $WordCloudImage.Width) / ($AverageFrequency * $SortedWordList.Count)
 
             :size do {
                 foreach ($Word in $SortedWordList) {

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -367,17 +367,6 @@ function New-WordCloud {
         [string]
         $OutputFormat = "Png",
 
-        [Parameter()]
-        [Alias('MaxWords')]
-        [ValidateRange(10, 500)]
-        [int]
-        $MaxUniqueWords = 100,
-
-        [Parameter()]
-        [Alias('DisableRotation', 'NoRotation')]
-        [switch]
-        $DisableWordRotation,
-
         [Parameter(Mandatory, ParameterSetName = 'FileBackground')]
         [Parameter(Mandatory, ParameterSetName = 'FileBackground-Mono')]
         [Alias('BaseImage')]
@@ -386,9 +375,20 @@ function New-WordCloud {
         $BackgroundImage,
 
         [Parameter()]
+        [Alias('MaxWords')]
+        [ValidateRange(10, 500)]
+        [int]
+        $MaxUniqueWords = 100,
+
+        [Parameter()]
         [Alias('Seed')]
         [int]
         $RandomSeed,
+
+        [Parameter()]
+        [Alias('Spacing')]
+        [double]
+        $Padding = 1,
 
         [Parameter()]
         [Alias('DisableClipping', 'NoClip')]
@@ -396,9 +396,14 @@ function New-WordCloud {
         $AllowOverflow,
 
         [Parameter()]
-        [Alias('Spacing')]
-        [double]
-        $Padding = 1
+        [Alias('DisableRotation', 'NoRotation')]
+        [switch]
+        $DisableWordRotation,
+
+        [Parameter()]
+        [Alias('Boxy')]
+        [switch]
+        $BoxCollisions
     )
     begin {
         Write-Debug "Color set: $($ColorSet -join ', ')"
@@ -711,7 +716,13 @@ function New-WordCloud {
 
                                 if (-not $WordIntersects) {
                                     # Available location found; break loop and draw
-                                    $ExistingWords.Union($WordPath)
+                                    if ($BoxCollisions) {
+                                        $ExistingWords.Union($Bounds)
+                                    }
+                                    else {
+                                        $ExistingWords.Union($WordPath)
+                                    }
+
                                     break
                                 }
                             }
@@ -727,7 +738,7 @@ function New-WordCloud {
                     $RadialDistance += $RNG.NextDouble() * ($Bounds.Width + $Bounds.Height) * $DistanceStep / 20
                 } while ($WordIntersects)
 
-                if ($WordIntersects) { continue }
+                if ($WordIntersects) { continue words }
 
                 $ColorIndex++
                 if ($ColorIndex -ge $ColorList.Count) {

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -273,7 +273,7 @@ function New-WordCloud {
                     return [ColorTransformAttribute]::ColorNames
                 }
                 else {
-                    return [ColorTransformAttribute]::ColorNames.Where{ $_.StartsWith($WordToComplete) }
+                    return [ColorTransformAttribute]::ColorNames.Where{ $_ -match "^$WordToComplete" }
                 }
             }
         )]
@@ -317,7 +317,7 @@ function New-WordCloud {
                     return [ColorTransformAttribute]::ColorNames
                 }
                 else {
-                    return [ColorTransformAttribute]::ColorNames.Where{ $_.StartsWith($WordToComplete) }
+                    return [ColorTransformAttribute]::ColorNames.Where{ $_ -match "^$WordToComplete" }
                 }
             }
         )]
@@ -369,7 +369,7 @@ function New-WordCloud {
                     return [ColorTransformAttribute]::ColorNames
                 }
                 else {
-                    return [ColorTransformAttribute]::ColorNames.Where{ $_.StartsWith($WordToComplete) }
+                    return [ColorTransformAttribute]::ColorNames.Where{ $_ -match "^$WordToComplete" }
                 }
             }
         )]
@@ -440,7 +440,7 @@ function New-WordCloud {
         $SplitChars = " `n.,`"?!{}[]:()`“`”™*#%^&+=" -as [char[]]
         $ColorIndex = 0
         $RadialDistance = 0
-        $GraphicsUnit = [GraphicsUnit]::Display
+        $GraphicsUnit = [GraphicsUnit]::Pixel
 
         $WordList = [List[string]]::new()
         $WordHeightTable = @{}
@@ -776,7 +776,7 @@ function New-WordCloud {
                                     Activity         = "Testing draw location"
                                     CurrentOperation = "Checking for sufficient space to draw at {0} {1}" -f @(
                                         $DrawLocation
-                                        @('Vertically', 'Horizontally')[$Format -ne [StringFormatFlags]::DirectionVertical]
+                                        @('Vertically', 'Horizontally')[$Format.FormatFlags -ne [StringFormatFlags]::DirectionVertical]
                                     )
                                     ParentId         = $ProgressID
                                     Id               = $ProgressID + 1


### PR DESCRIPTION
# Fixes and Improvements

* Add rotation checks for both orientations at each position (first chosen orientation selected randomly)
* Use Region to store paths and check IsVisible against the new word's bounds to get much better and closer collision detection.
* Fix up `-WordScale` param to... actually work...
* Allow setting `0` on `-MaxWords` to display all words that scale large enough to be rendered.
* Set fixed resolution values to 96 DPI to hopefully fix some issues on Mac OS.

# New Features (WIP)

* Add `-StrokeColor` and `-StrokeWidth` parameters
* Add `-BoxCollisions` switch to revert back to prior collision detection behaviour
* Add `-Padding` parameter to increase or decrease word collision boundary sizing
* Add `-AllowOverflow` switch to permit the word cloud to overflow the image boundaries somewhat
* Display Write-Progress information of where words are being placed because this is pretty slow tbh
