### PR TITLE
Massive Perf Improvements & More toys

### DIFF
--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -798,6 +798,7 @@ function New-WordCloud {
 
                             try {
                                 $WordPath = [Drawing2d.GraphicsPath]::new()
+                                $WordPath.FillMode = [Drawing2D.FillMode]::Winding
                                 $WordPath.AddString(
                                     $Word,
                                     $FontFamily,

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -708,6 +708,7 @@ function New-WordCloud {
             $MaxRadialDistance = [Math]::Max($UsableSpace.Width, $UsableSpace.Height) / 2
             $ForbiddenArea.Exclude($UsableSpace)
             $WordCount = 0
+            $WordPath = [Drawing2d.GraphicsPath]::new()
 
             :words foreach ($Word in $SortedWordList) {
                 $WordCount++
@@ -797,7 +798,7 @@ function New-WordCloud {
                             }
 
                             try {
-                                $WordPath = [Drawing2d.GraphicsPath]::new()
+                                $WordPath.Reset()
                                 $WordPath.FillMode = [Drawing2D.FillMode]::Winding
                                 $WordPath.AddString(
                                     $Word,

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -858,7 +858,7 @@ function New-WordCloud {
                     }
 
                     # No available free space anywhere in this radial scan, keep scanning
-                    $RadialDistance += $RNG.NextDouble() * ($Bounds.Width + $Bounds.Height) * $DistanceStep / 20
+                    $RadialDistance += $RNG.NextDouble() * ($Bounds.Width + $Bounds.Height) * $DistanceStep / [Math]::Max(1, 21 - $Padding)
                 } while ($WordIntersects)
             }
             # All words written that we can

--- a/PSWordCloud/Public/New-WordCloud.ps1
+++ b/PSWordCloud/Public/New-WordCloud.ps1
@@ -245,8 +245,8 @@ function New-WordCloud {
 
     .PARAMETER Padding
     Specify the bounded spacing between words. This is calculated as additional distance from the prior drawn paths and
-    each new word placement attempt. Higher values will tend to take longer to render, but tend to look neater. 1 is the
-    default. Specify 0 for no minimum spacing and negative values to allow words to overlap.
+    each new word placement attempt. Higher values will tend to take longer to render, but tend to look neater. 3.5 is
+    the default. Specify 0 for no minimum spacing and negative values to allow words to overlap.
 
     .PARAMETER WordScale
     Adjust the word scaling. 1 is the default.
@@ -459,7 +459,7 @@ function New-WordCloud {
         [Parameter()]
         [Alias('Spacing')]
         [double]
-        $Padding = 1,
+        $Padding = 3.5,
 
         [Parameter()]
         [Alias('Scale', 'FontScale')]


### PR DESCRIPTION
## Fixes

* Uses `Winding` path fill mode to avoid text overlaps creating gaps
* Adjust distance steps to be wider when using more padding
* Reuse words' GraphicsPath when rendering instead of re-creating the object
* Modifications to verbose output to simplify and focus on what's important

## New Stuff

* Add `-ExcludeWord` to specify custom excluded words
* Add `-AllowStopWords` to ignore the default exclusions
* _Multithreaded_ word crunching! Crunch 800,000 words in mere moments and start rendering right away!