### PR TITLE
Allow more degrees of freedom for word rotations

### DIFF
--- a/Module/src/NewWordCloudCommand.cs
+++ b/Module/src/NewWordCloudCommand.cs
@@ -384,7 +384,7 @@ namespace PSWordCloud
 
         private float NextDrawAngle()
         {
-            switch (RotationStyle)
+            switch (AllowRotation)
             {
                 case WordOrientations.Vertical:
                     return RandomFloat() > 0.5 ? 0 : 90;
@@ -544,7 +544,7 @@ namespace PSWordCloud
                 scaledWordSizes = new Dictionary<string, float>(
                     sortedWordList.Count, StringComparer.OrdinalIgnoreCase);
 
-                maxWordWidth = RotationStyle == WordOrientations.None
+                maxWordWidth = AllowRotation == WordOrientations.None
                     ? drawableBounds.Width * MAX_WORD_WIDTH_PERCENT
                     : Math.Max(drawableBounds.Width, drawableBounds.Height) * MAX_WORD_WIDTH_PERCENT;
 

--- a/Module/src/NewWordCloudCommand.cs
+++ b/Module/src/NewWordCloudCommand.cs
@@ -320,12 +320,11 @@ namespace PSWordCloud
         public int RandomSeed { get; set; }
 
         /// <summary>
-        /// Gets or sets whether or not to disable rotation of words. Selecting this option will result in a more
-        /// uniform cloud, where all words are drawn horizontally.
+        /// Gets or sets which types of word rotations are used when drawing the word cloud.
         /// </summary>
         [Parameter()]
         [Alias("DisableWordRotation")]
-        public SwitchParameter DisableRotation { get; set; }
+        public WordOrientations RotationStyle { get; set; } = WordOrientations.EitherVertical;
 
         /// <summary>
         /// Gets or sets whether to draw the cloud in monochrome (greyscale).
@@ -383,23 +382,59 @@ namespace PSWordCloud
             return color;
         }
 
-        private WordOrientation GetWordOrientation()
+        private float NextDrawAngle()
         {
-            if (!DisableRotation)
+            switch (RotationStyle)
             {
-                var num = RandomFloat();
-                if (num > 0.75)
-                {
-                    return WordOrientation.Vertical;
-                }
-
-                if (num > 0.5)
-                {
-                    return WordOrientation.FlippedVertical;
-                }
+                case WordOrientations.Vertical:
+                    return RandomFloat() > 0.5 ? 0 : 90;
+                case WordOrientations.FlippedVertical:
+                    return RandomFloat() < 0.5 ? 0 : -90;
+                case WordOrientations.EitherVertical:
+                    return RandomFloat() < 0.5
+                        ? 0
+                        : RandomFloat() > 0.5
+                            ? 90
+                            : -90;
+                case WordOrientations.UprightDiagonals:
+                    switch (RandomInt(0, 5))
+                    {
+                        case 0: return -90;
+                        case 1: return -45;
+                        case 2: return 45;
+                        case 3: return 90;
+                        case 4: default: return 0;
+                    }
+                case WordOrientations.InvertedDiagonals:
+                    switch (RandomInt(0, 5))
+                    {
+                        case 0: return 90;
+                        case 1: return 135;
+                        case 2: return -135;
+                        case 3: return -90;
+                        case 4: default: return 180;
+                    }
+                case WordOrientations.AllDiagonals:
+                    switch (RandomInt(0, 8))
+                    {
+                        case 0: return 45;
+                        case 1: return 90;
+                        case 2: return 135;
+                        case 3: return 180;
+                        case 4: return -135;
+                        case 5: return -90;
+                        case 6: return -45;
+                        case 7: default: return 0;
+                    }
+                case WordOrientations.AllUpright:
+                    return RandomInt(-90, 91);
+                case WordOrientations.AllInverted:
+                    return RandomInt(90, 271);
+                case WordOrientations.All:
+                    return RandomInt(0, 361);
+                default:
+                    return 0;
             }
-
-            return WordOrientation.Horizontal;
         }
 
         private float _paddingMultiplier => Padding * PADDING_BASE_SCALE;
@@ -509,7 +544,7 @@ namespace PSWordCloud
                 scaledWordSizes = new Dictionary<string, float>(
                     sortedWordList.Count, StringComparer.OrdinalIgnoreCase);
 
-                maxWordWidth = DisableRotation
+                maxWordWidth = RotationStyle == WordOrientations.None
                     ? drawableBounds.Width * MAX_WORD_WIDTH_PERCENT
                     : Math.Max(drawableBounds.Width, drawableBounds.Height) * MAX_WORD_WIDTH_PERCENT;
 
@@ -595,7 +630,6 @@ namespace PSWordCloud
                         canvas.Clear(BackgroundColor);
                     }
 
-                    WordOrientation targetOrientation;
                     SKPoint targetPoint;
 
                     brush.IsAutohinted = true;
@@ -617,7 +651,6 @@ namespace PSWordCloud
                         wordCount++;
 
                         inflationValue = scaledWordSizes[word] * (_paddingMultiplier + StrokeWidth * STROKE_BASE_SCALE);
-                        targetOrientation = WordOrientation.Horizontal;
                         targetPoint = SKPoint.Empty;
 
                         var wordColor = GetNextColor();
@@ -657,10 +690,10 @@ namespace PSWordCloud
                                     continue;
                                 }
 
-                                var orientation = GetWordOrientation();
+                                var drawAngle = NextDrawAngle();
                                 pointProgress.Activity = string.Format(
-                                    "Finding available space to draw with orientation: {0}",
-                                    orientation);
+                                    "Finding available space to draw at angle: {0}",
+                                    drawAngle);
                                 pointProgress.StatusDescription = string.Format(
                                     "Checking [Point:{0,8:N2}, {1,8:N2}] ({2,4} / {3,4}) at [Radius: {4,8:N2}]",
                                     point.X, point.Y, pointsChecked, totalPoints, radius);
@@ -672,7 +705,7 @@ namespace PSWordCloud
                                     (wordHeight / 2));
                                 adjustedPoint = point + baseOffset;
 
-                                SKMatrix rotation = GetRotationMatrix(point, orientation);
+                                SKMatrix rotation = SKMatrix.MakeRotationDegrees(drawAngle, point.X, point.Y);
 
                                 SKPath alteredPath = brush.GetTextPath(word, adjustedPoint.X, adjustedPoint.Y);
                                 alteredPath.Transform(rotation);
@@ -685,7 +718,6 @@ namespace PSWordCloud
                                     // First word will always be drawn in the centre.
                                     wordPath = alteredPath;
                                     targetPoint = adjustedPoint;
-                                    targetOrientation = orientation;
                                     goto nextWord;
                                 }
                                 else
@@ -699,7 +731,6 @@ namespace PSWordCloud
                                     {
                                         wordPath = alteredPath;
                                         targetPoint = adjustedPoint;
-                                        targetOrientation = orientation;
                                         goto nextWord;
                                     }
                                 }
@@ -766,27 +797,6 @@ namespace PSWordCloud
         }
 
         #region HelperMethods
-
-        /// <summary>
-        /// Creates a matrix to rotate drawing objects around the given point, according to the orientation specified.
-        /// </summary>
-        /// <param name="point">The "centre" point for the rotation.</param>
-        /// <param name="orientation">The target word orientation the rotation should result in.</param>
-        /// <returns>A matrix that defines the correct rotation for the given WordOrientation.</returns>
-        private static SKMatrix GetRotationMatrix(SKPoint point, WordOrientation orientation)
-        {
-            switch (orientation)
-            {
-                case WordOrientation.Vertical:
-                    return SKMatrix.MakeRotationDegrees(90, point.X, point.Y);
-
-                case WordOrientation.FlippedVertical:
-                    return SKMatrix.MakeRotationDegrees(-90, point.X, point.Y);
-
-                default:
-                    return SKMatrix.MakeIdentity();
-            }
-        }
 
         /// <summary>
         /// Processes the color set to ensure no colors identical to the background or stroke colors are re-used,
@@ -978,6 +988,14 @@ namespace PSWordCloud
             lock (_randomLock)
             {
                 return Random.Next();
+            }
+        }
+
+        private static int RandomInt(int min, int max)
+        {
+            lock (_randomLock)
+            {
+                return Random.Next(min, max);
             }
         }
 

--- a/Module/src/NewWordCloudCommand.cs
+++ b/Module/src/NewWordCloudCommand.cs
@@ -323,8 +323,8 @@ namespace PSWordCloud
         /// Gets or sets which types of word rotations are used when drawing the word cloud.
         /// </summary>
         [Parameter()]
-        [Alias("DisableWordRotation")]
-        public WordOrientations RotationStyle { get; set; } = WordOrientations.EitherVertical;
+        [Alias()]
+        public WordOrientations AllowRotation { get; set; } = WordOrientations.EitherVertical;
 
         /// <summary>
         /// Gets or sets whether to draw the cloud in monochrome (greyscale).

--- a/Module/src/WCUtils.cs
+++ b/Module/src/WCUtils.cs
@@ -11,11 +11,19 @@ using SkiaSharp;
 [assembly: InternalsVisibleTo("PSWordCloud.Tests")]
 namespace PSWordCloud
 {
-    internal enum WordOrientation : sbyte
+    [Flags()]
+    public enum WordOrientations : sbyte
     {
-        Horizontal,
-        Vertical,
-        FlippedVertical,
+        None = 0x0,
+        Vertical = 0x1,
+        FlippedVertical = 0x2,
+        EitherVertical = Vertical | FlippedVertical,
+        UprightDiagonals = 0x4,
+        InvertedDiagonals = 0x8,
+        AllDiagonals = UprightDiagonals | InvertedDiagonals,
+        AllUpright = 0x10,
+        AllInverted = 0x20,
+        All = AllUpright | AllInverted
     }
 
     internal static class WCUtils

--- a/Module/src/WCUtils.cs
+++ b/Module/src/WCUtils.cs
@@ -11,19 +11,18 @@ using SkiaSharp;
 [assembly: InternalsVisibleTo("PSWordCloud.Tests")]
 namespace PSWordCloud
 {
-    [Flags()]
     public enum WordOrientations : sbyte
     {
-        None = 0x0,
-        Vertical = 0x1,
-        FlippedVertical = 0x2,
-        EitherVertical = Vertical | FlippedVertical,
-        UprightDiagonals = 0x4,
-        InvertedDiagonals = 0x8,
-        AllDiagonals = UprightDiagonals | InvertedDiagonals,
-        AllUpright = 0x10,
-        AllInverted = 0x20,
-        All = AllUpright | AllInverted
+        None,
+        Vertical,
+        FlippedVertical,
+        EitherVertical,
+        UprightDiagonals,
+        InvertedDiagonals,
+        AllDiagonals,
+        AllUpright,
+        AllInverted,
+        All,
     }
 
     internal static class WCUtils

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -19,7 +19,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-AllowStopWords]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-AllowStopWords]
  [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
@@ -29,7 +29,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-Monochrome] [-AllowStopWords]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-Monochrome] [-AllowStopWords]
  [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
@@ -39,7 +39,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-AllowStopWords] [-AllowOverflow] [-PassThru]
+ [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-AllowStopWords] [-AllowOverflow] [-PassThru]
  [<CommonParameters>]
 ```
 
@@ -49,7 +49,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-Monochrome] [-AllowStopWords] [-AllowOverflow]
+ [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-Monochrome] [-AllowStopWords] [-AllowOverflow]
  [-PassThru] [<CommonParameters>]
 ```
 
@@ -132,6 +132,25 @@ Aliases: AllowBleed
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowRotation
+
+Specify -AllowRotation None to prevent word rotation entirely, or use one of the options to permit specific rotation modes.
+
+All modes permit the "upright" standard orientation, as well as their specified additions.
+
+```yaml
+Type: WordOrientations
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Vertical, FlippedVertical, EitherVertical, UprightDiagonals, InvertedDiagonals, AllDiagonals, AllUpright, AllInverted, All
+
+Required: False
+Position: Named
+Default value: EitherVertical
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -486,23 +505,6 @@ Aliases: SeedValue
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RotationStyle
-
-Specify the rotation modes permitted when drawing the word cloud.
-
-```yaml
-Type: WordOrientations
-Parameter Sets: (All)
-Aliases: DisableWordRotation
-Accepted values: None, Vertical, FlippedVertical, EitherVertical, UprightDiagonals, InvertedDiagonals, AllDiagonals, AllUpright, AllInverted, All
-
-Required: False
-Position: Named
-Default value: EitherVertical
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -19,8 +19,8 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-DisableRotation] [-AllowStopWords] [-AllowOverflow] [-PassThru]
- [<CommonParameters>]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-AllowStopWords]
+ [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ### ColorBackground-Mono
@@ -29,8 +29,8 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-DisableRotation] [-Monochrome] [-AllowStopWords] [-AllowOverflow]
- [-PassThru] [<CommonParameters>]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-Monochrome] [-AllowStopWords]
+ [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ### FileBackground
@@ -39,7 +39,8 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-DisableRotation] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-AllowStopWords] [-AllowOverflow] [-PassThru]
+ [<CommonParameters>]
 ```
 
 ### FileBackground-Mono
@@ -48,8 +49,8 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-DisableRotation] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru]
- [<CommonParameters>]
+ [-RandomSeed <Int32>] [-RotationStyle <WordOrientations>] [-Monochrome] [-AllowStopWords] [-AllowOverflow]
+ [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -229,22 +230,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: *
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisableRotation
-
-When this option is specified, New-WordCloud draws all words horizontally.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: DisableWordRotation
-
-Required: False
-Position: Named
-Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -501,6 +486,23 @@ Aliases: SeedValue
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RotationStyle
+
+Specify the rotation modes permitted when drawing the word cloud.
+
+```yaml
+Type: WordOrientations
+Parameter Sets: (All)
+Aliases: DisableWordRotation
+Accepted values: None, Vertical, FlippedVertical, EitherVertical, UprightDiagonals, InvertedDiagonals, AllDiagonals, AllUpright, AllInverted, All
+
+Required: False
+Position: Named
+Default value: EitherVertical
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

## Changes

* Replaces the `-DisableRotation` switch with a new parameter `-AllowRotation`, with the following possible values:
  * None (Equivalent to -DisableRotation)
  * Vertical
  * FlippedVertical
  * FlippedVertical
  * EitherVertical
  * UprightDiagonals
  * InvertedDiagonals
  * AllDiagonals
  * AllUpright
  * AllInverted
  * All
* Internal changes to how rotations are handled, mainly just to pull rotation angles and then create a rotation matrix directly.

## Examples

The below examples use the following command to generate the cloud, only adding the -AllowRotation mode for that test:

```powershell
$poem | New-WordCloud -Path .\test.svg -ImageSize 800 -Typeface "Segoe Print" -FocusWord Hollow 
```

`$poem` contains the poem text from [this page](http://www.poetsforum.com/poems/hollow/)

### -AllowRotation None

![None](https://svgshare.com/i/Bqf.svg)

### -AllowRotation Vertical

![Vertical](https://svgshare.com/i/Bqz.svg)

### -AllowRotation FlippedVertical

![FlippedVertical](https://svgshare.com/i/Bqr.svg)

### -AllowRotation EitherVertical (Default)

![EitherVertical](https://svgshare.com/i/Boi.svg)

### -AllowRotation UprightDiagonals

![UprightDiagonals](https://svgshare.com/i/Bqs.svg)

### -AllowRotation InvertedDiagonals

![InvertedDiagonals](https://svgshare.com/i/BpG.svg)

### -AllowRotation AllDiagonals

![AllDiagonals](https://svgshare.com/i/Bq7.svg)

### -AllowRotation AllUpright

![AllUpright](https://svgshare.com/i/Bq8.svg)

### -AllowRotation AllInverted

![AllInverted](https://svgshare.com/i/BoZ.svg)

### -AllowRotation All

![All](https://svgshare.com/i/Br0.svg)

/cc @thomasrayner @TylerLeonhardt @Romero126 @steviecoaster

If y'all wouldn't mind giving this a look over and letting me know any thoughts you have, would be much appreciated!