### PR TITLE
Add `-RotateFocusWord` Parameter

### DIFF
--- a/Module/src/Attributes.cs
+++ b/Module/src/Attributes.cs
@@ -393,4 +393,21 @@ namespace PSWordCloud
         }
     }
 
+    public class AngleCompleter : IArgumentCompleter
+    {
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            for (float angle = 0; angle <= 360; angle += 45)
+            {
+                var s = LanguagePrimitives.ConvertTo<string>(angle);
+                yield return new CompletionResult(s, s, CompletionResultType.ParameterValue, s);
+            }
+        }
+    }
+
 }

--- a/Module/src/NewWordCloudCommand.cs
+++ b/Module/src/NewWordCloudCommand.cs
@@ -73,9 +73,9 @@ namespace PSWordCloud
         /// have a meaningful ToString() method override defined.
         /// </summary>
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "ColorBackground")]
-        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "ColorBackground-Mono")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "ColorBackground-FocusWord")]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "FileBackground")]
-        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "FileBackground-Mono")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = "FileBackground-FocusWord")]
         [Alias("InputString", "Text", "String", "Words", "Document", "Page")]
         [AllowEmptyString()]
         public PSObject InputObject { get; set; }
@@ -85,9 +85,9 @@ namespace PSWordCloud
         /// Gets or sets the output path to save the final SVG vector file to.
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ColorBackground")]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ColorBackground-Mono")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ColorBackground-FocusWord")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "FileBackground")]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "FileBackground-Mono")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "FileBackground-FocusWord")]
         [Alias("OutFile", "ExportPath", "ImagePath")]
         public string Path
         {
@@ -101,7 +101,7 @@ namespace PSWordCloud
         /// Gets or sets the path to the background image to be used as a base for the final word cloud image.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "FileBackground")]
-        [Parameter(Mandatory = true, ParameterSetName = "FileBackground-Mono")]
+        [Parameter(Mandatory = true, ParameterSetName = "FileBackground-FocusWord")]
         public string BackgroundImage
         {
             get => _backgroundFullPath;
@@ -139,7 +139,7 @@ namespace PSWordCloud
         /// </summary>
         /// <value>The default value is a size of 3840x2160.</value>
         [Parameter(ParameterSetName = "ColorBackground")]
-        [Parameter(ParameterSetName = "ColorBackground-Mono")]
+        [Parameter(ParameterSetName = "ColorBackground-FocusWord")]
         [ArgumentCompleter(typeof(ImageSizeCompleter))]
         [TransformToSKSizeI()]
         public SKSizeI ImageSize { get; set; } = new SKSizeI(3840, 2160);
@@ -236,9 +236,17 @@ namespace PSWordCloud
         /// Gets or sets the focus word string to be used in the word cloud. This string will typically appear in the
         /// centre of the cloud, larger than all the other words.
         /// </summary>
-        [Parameter()]
+        [Parameter(Mandatory = true, ParameterSetName = "ColorBackground-FocusWord")]
+        [Parameter(Mandatory = true, ParameterSetName = "FileBackground-FocusWord")]
         [Alias("Title")]
         public string FocusWord { get; set; }
+
+        [Parameter(ParameterSetName = "ColorBackground-FocusWord")]
+        [Parameter(ParameterSetName = "FileBackground-FocusWord")]
+        [Alias("RotateTitle")]
+        [ArgumentCompleter(typeof(AngleCompleter))]
+        [ValidateRange(-360, 360)]
+        public float RotateFocusWord { get; set; }
 
         /// <summary>
         /// <para>Gets or sets the words to be explicitly ignored when rendering the word cloud.</para>
@@ -267,6 +275,13 @@ namespace PSWordCloud
         [Alias("ScaleFactor")]
         [ValidateRange(0.01, 20)]
         public float WordScale { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets which types of word rotations are used when drawing the word cloud.
+        /// </summary>
+        [Parameter()]
+        [Alias()]
+        public WordOrientations AllowRotation { get; set; } = WordOrientations.EitherVertical;
 
         /// <summary>
         /// Gets or sets the float value to scale the padding space around the words by.
@@ -320,17 +335,9 @@ namespace PSWordCloud
         public int RandomSeed { get; set; }
 
         /// <summary>
-        /// Gets or sets which types of word rotations are used when drawing the word cloud.
-        /// </summary>
-        [Parameter()]
-        [Alias()]
-        public WordOrientations AllowRotation { get; set; } = WordOrientations.EitherVertical;
-
-        /// <summary>
         /// Gets or sets whether to draw the cloud in monochrome (greyscale).
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "FileBackground-Mono")]
-        [Parameter(Mandatory = true, ParameterSetName = "ColorBackground-Mono")]
+        [Parameter()]
         [Alias("BlackAndWhite", "Greyscale")]
         public SwitchParameter Monochrome { get; set; }
 
@@ -663,6 +670,11 @@ namespace PSWordCloud
                         var wordWidth = wordBounds.Width;
                         var wordHeight = wordBounds.Height;
 
+                        float drawAngle = wordCount == 1
+                            && MyInvocation.BoundParameters.ContainsKey(nameof(RotateFocusWord))
+                                ? drawAngle = RotateFocusWord
+                                : drawAngle = NextDrawAngle();
+
                         var percentComplete = 100f * wordCount / scaledWordSizes.Count;
 
                         wordProgress.StatusDescription = string.Format(
@@ -690,7 +702,6 @@ namespace PSWordCloud
                                     continue;
                                 }
 
-                                var drawAngle = NextDrawAngle();
                                 pointProgress.Activity = string.Format(
                                     "Finding available space to draw at angle: {0}",
                                     drawAngle);

--- a/Module/src/NewWordCloudCommand.cs
+++ b/Module/src/NewWordCloudCommand.cs
@@ -177,7 +177,7 @@ namespace PSWordCloud
         /// </summary>
         /// <value>The default value is SKColors.Black.</value>
         [Parameter(ParameterSetName = "ColorBackground")]
-        [Parameter(ParameterSetName = "ColorBackground-Mono")]
+        [Parameter(ParameterSetName = "ColorBackground-FocusWord")]
         [Alias("Backdrop", "CanvasColor")]
         [ArgumentCompleter(typeof(SKColorCompleter))]
         [TransformToSKColor()]

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -510,7 +510,9 @@ Accept wildcard characters: False
 
 ### -RotateFocusWord
 
-Specify an angle to rotate the focus word by, overriding the default random rotations for the focus word only.
+Specify an angle in degrees to rotate the focus word by, overriding the default random rotations for the focus word only.
+
+Values from -360 to 360, including sub-degree increments, are permitted.
 
 ```yaml
 Type: Single

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -17,40 +17,39 @@ Describes the syntax and behaviour of the New-WordCloud cmdlet.
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
- [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
+ [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-AllowStopWords]
- [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru]
+ [<CommonParameters>]
 ```
 
-### ColorBackground-Mono
+### ColorBackground-FocusWord
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
- [-FocusWord <String>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
- [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-Monochrome] [-AllowStopWords]
- [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ -FocusWord <String> [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
+ [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>]
+ [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome]
+ [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ### FileBackground
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
- [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
- [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
+ [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-ExcludeWord <String[]>]
+ [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-AllowStopWords] [-AllowOverflow] [-PassThru]
- [<CommonParameters>]
+ [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
-### FileBackground-Mono
+### FileBackground-FocusWord
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
- [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-FocusWord <String>]
- [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-Padding <Single>]
- [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-AllowRotation <WordOrientations>] [-Monochrome] [-AllowStopWords] [-AllowOverflow]
- [-PassThru] [<CommonParameters>]
+ [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
+ [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
+ [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>]
+ [-MaxRenderedWords <Int32>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords]
+ [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -205,7 +204,7 @@ Accepts input as a complete SKColor object, or one of the following formats:
 
 ```yaml
 Type: SKColor
-Parameter Sets: ColorBackground, ColorBackground-Mono
+Parameter Sets: ColorBackground, ColorBackground-FocusWord
 Aliases: Backdrop, CanvasColor
 
 Required: False
@@ -221,7 +220,7 @@ Specifies the path to the background image to be used as a base for the final wo
 
 ```yaml
 Type: String
-Parameter Sets: FileBackground, FileBackground-Mono
+Parameter Sets: FileBackground, FileBackground-FocusWord
 Aliases:
 
 Required: True
@@ -296,10 +295,10 @@ the centre of the cloud, larger than all the other words.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord
 Aliases: Title
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -327,7 +326,7 @@ Input can be passed directly as a [SkiaSharp.SKSizeI] object, or in one of the f
 
 ```yaml
 Type: SKSizeI
-Parameter Sets: ColorBackground, ColorBackground-Mono
+Parameter Sets: ColorBackground, ColorBackground-FocusWord
 Aliases:
 
 Required: False
@@ -417,10 +416,10 @@ Only the Brightness values from the SKColors in the color set provided will be u
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ColorBackground-Mono, FileBackground-Mono
+Parameter Sets: (All)
 Aliases: BlackAndWhite, Greyscale
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -501,6 +500,22 @@ Determines the seed value for the random numbers used to vary the position and p
 Type: Int32
 Parameter Sets: (All)
 Aliases: SeedValue
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RotateFocusWord
+
+Specify an angle to rotate the focus word by, overriding the default random rotations for the focus word only.
+
+```yaml
+Type: Single
+Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord
+Aliases: RotateTitle
 
 Required: False
 Position: Named


### PR DESCRIPTION
# PR Summary

Fixes #19 and adds `-RotateFocusWord` to allow the focus word to be oriented in a specific way.

## Changes

* Adds a `-RotateFocusWord` parameter.
  * Although the argumentcompleter only suggests angles at 45 degree increments, any angle can be used, even in sub-degree increments.
* Updated help
* Updated parameter sets; the `*-Mono` sets weren't actually needed, so they were supplanted by `-FocusWord` sets.

