### PR TITLE
:wrench: Fix Windows PowerShell Compatibility

### DIFF
--- a/Module/PSWordCloud.psm1
+++ b/Module/PSWordCloud.psm1
@@ -18,6 +18,8 @@ $SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder |
     Join-Path -ChildPath "SkiaSharp.dll"
 
 Add-Type -Path $SkiaDllPath
-Import-Module  "$PSScriptRoot/PSWordCloudCmdlet.dll"
+
+$ModuleDllPath = Join-Path -Path $PSScriptRoot -ChildPath "PSWordCloudCmdlet.dll"
+Import-Module $ModuleDllPath
 
 Export-ModuleMember -Cmdlet "New-WordCloud"

--- a/Module/PSWordCloud.psm1
+++ b/Module/PSWordCloud.psm1
@@ -8,11 +8,16 @@
     $IsLinux {
         "linux-x64"
     }
+    default {
+        # Windows PowerShell
+        if ([Environment]::Is64BitProcess) { "win-x64" } else { "win-x86" }
+    }
 }
 
-$SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder "SkiaSharp.dll"
+$SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder |
+    Join-Path -ChildPath "SkiaSharp.dll"
 
 Add-Type -Path $SkiaDllPath
-Import-Module  "$PSScriptRoot\PSWordCloudCmdlet.dll"
+Import-Module  "$PSScriptRoot/PSWordCloudCmdlet.dll"
 
 Export-ModuleMember -Cmdlet "New-WordCloud"


### PR DESCRIPTION
# PR Summary

Fixes #22
Reworked the PSM1 to avoid PS6-specific code.

## Changes

* Add `default{}` case to the switch as none of the `$Is<Platform>` variables exist on WinPS
* Use older `Join-Path` syntaxes (`-AdditionalChildPath` is PS6+)

