### PR TITLE
Fix: "Type initializer for WCUtils threw and exception" on calling New-WordCloud in 6.2.0

### DIFF
--- a/Module/PSWordCloud.psm1
+++ b/Module/PSWordCloud.psm1
@@ -1,25 +1,30 @@
-﻿$PlatformFolder = switch ($true) {
+﻿Add-Type -TypeDefinition @"
+    using System.Runtime.InteropServices;
+
+    public class DllLoadPath
+    {
+        [DllImport("kernel32", CharSet=CharSet.Unicode)]
+        public static extern int AddDllDirectory(string NewDirectory);
+    }
+"@
+
+$PlatformFolder = switch ($true) {
     $IsWindows {
         if ([Environment]::Is64BitProcess) { "win-x64" } else { "win-x86" }
     }
-    $IsMacOS {
-        "osx"
-    }
-    $IsLinux {
-        "linux-x64"
-    }
+    $IsMacOS { "osx" }
+    $IsLinux { "linux-x64" }
     default {
         # Windows PowerShell
         if ([Environment]::Is64BitProcess) { "win-x64" } else { "win-x86" }
     }
 }
 
-$SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder |
-    Join-Path -ChildPath "SkiaSharp.dll"
+$NativeRuntimeFolder = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder
+[DllLoadPath]::AddDllDirectory($NativeRuntimeFolder)
 
+$SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath "SkiaSharp.dll"
 Add-Type -Path $SkiaDllPath
 
 $ModuleDllPath = Join-Path -Path $PSScriptRoot -ChildPath "PSWordCloudCmdlet.dll"
 Import-Module $ModuleDllPath
-
-Export-ModuleMember -Cmdlet "New-WordCloud"

--- a/Module/PSWordCloud.psm1
+++ b/Module/PSWordCloud.psm1
@@ -4,7 +4,7 @@
     public class DllLoadPath
     {
         [DllImport("kernel32", CharSet=CharSet.Unicode)]
-        public static extern int AddDllDirectory(string NewDirectory);
+        public static extern int SetDllDirectory(string NewDirectory);
     }
 "@
 
@@ -21,10 +21,10 @@ $PlatformFolder = switch ($true) {
 }
 
 $NativeRuntimeFolder = Join-Path -Path $PSScriptRoot -ChildPath $PlatformFolder
-[DllLoadPath]::AddDllDirectory($NativeRuntimeFolder)
+[DllLoadPath]::SetDllDirectory($NativeRuntimeFolder)
 
 $SkiaDllPath = Join-Path -Path $PSScriptRoot -ChildPath "SkiaSharp.dll"
 Add-Type -Path $SkiaDllPath
 
-$ModuleDllPath = Join-Path -Path $PSScriptRoot -ChildPath "PSWordCloudCmdlet.dll"
-Import-Module $ModuleDllPath
+Join-Path -Path $PSScriptRoot -ChildPath "PSWordCloudCmdlet.dll" |
+    Import-Module

--- a/build.ps1
+++ b/build.ps1
@@ -35,21 +35,18 @@ $SupportedPlatforms = "win-x64", "win-x86", "linux-x64", "osx"
 $ModulePath = Join-Path $OutputPath -ChildPath "PSWordCloud"
 New-Item -Path $ModulePath -ItemType Directory | Out-Null
 
-# Copy the main module DLL to final module directory
+# Copy the main module DLLs to final module directory
 Copy-Item -Path "$OutputPath/bin/PSWordCloudCmdlet.dll" -Destination $ModulePath
+Copy-Item -Path "$OutputPath/bin/SkiaSharp.dll" -Destination $ModulePath
 
-# Get the main Skia DLL
-$SkiaDLL = Get-Item -Path "$OutputPath/bin/SkiaSharp.dll"
-
-# Get platform-specific runtime library folders for Skia
+# Copy platform-specific runtime library folders for Skia
 $RuntimeFolders = Get-ChildItem -Path "$OutputPath/bin/runtimes" |
     Where-Object Name -in $SupportedPlatforms
 
 $RuntimeFolders | ForEach-Object {
     $OutputDirectory = New-Item -ItemType Directory -Path "$ModulePath/$($_.Name)"
     Get-ChildItem -Path $_.FullName -Recurse -Include *.dylib, *.dll, *.so |
-        Copy-Item -Destination $OutputDirectory.FullName -PassThru |
-        ForEach-Object { Copy-Item -Path $SkiaDLL.FullName -Destination $OutputDirectory.FullName }
+        Copy-Item -Destination $OutputDirectory.FullName
 }
 
 Split-Path -Path $ProjectFile -Parent |

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -617,7 +617,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
# PR Summary

Something changed in either .NET Core or PowerShell as of 6.2.0-preview2, and the current method of relying on the SkiaSharp.dll looking in its own folder for the native libraries stopped working. Unsure why; there is a related issue tracking that: https://github.com/PowerShell/PowerShell/issues/9488

This works around that by calling a win32 API method `SetDllDirectory()` to force the addition of the platform-specific runtime folder to the search paths. With this change, it is no longer necessary to ship multiple copies of the main SkiaSharp.dll and the build script was updated accordingly.

Despite the extra p/invoke (gag) necessary here, it appears to be a more robust solution than previous.