### PR TITLE
Miscellaneous Tweaks for v3.0 Release

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/PSWordCloud.Tests/PSWordCloud.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/PSWordCloud.Tests/PSWordCloud.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/PSWordCloud.Tests/PSWordCloud.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Module/src/PSWordCloud/Attributes.cs
+++ b/Module/src/PSWordCloud/Attributes.cs
@@ -124,7 +124,7 @@ namespace PSWordCloud
 
                     break;
                 case object o:
-                    IEnumerable properties = null;
+                    IEnumerable properties;
                     if (o is Hashtable ht)
                     {
                         properties = ht;
@@ -195,7 +195,7 @@ namespace PSWordCloud
                 case string s:
                     return WCUtils.FontManager.MatchFamily(s, SKFontStyle.Normal);
                 default:
-                    IEnumerable properties = null;
+                    IEnumerable properties;
                     if (inputData is Hashtable ht)
                     {
                         properties = ht;
@@ -223,8 +223,9 @@ namespace PSWordCloud
                     }
                     else
                     {
-                        var customStyle = properties.GetValue("FontStyle") as SKFontStyle;
-                        style = customStyle == null ? SKFontStyle.Normal : customStyle;
+                        style = properties.GetValue("FontStyle") is SKFontStyle customStyle
+                            ? customStyle
+                            : SKFontStyle.Normal;
                     }
 
                     string familyName = LanguagePrimitives.ConvertTo<string>(properties.GetValue("FamilyName"));
@@ -325,7 +326,7 @@ namespace PSWordCloud
                     continue;
                 }
 
-                IEnumerable properties = null;
+                IEnumerable properties;
                 if (item is Hashtable ht)
                 {
                     properties = ht;
@@ -362,33 +363,16 @@ namespace PSWordCloud
 
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
-            SKColor[] results;
             switch (inputData)
             {
                 case string s:
-                    results = MatchColor(s).ToArray();
-                    if (results.Length == 1)
-                    {
-                        return results[0];
-                    }
-                    else
-                    {
-                        return results;
-                    }
+                    return Normalize(MatchColor(s));
 
                 case SKColor color:
                     return color;
 
                 default:
-                    results = TransformObject(inputData).ToArray();
-                    if (results.Length == 1)
-                    {
-                        return results[0];
-                    }
-                    else
-                    {
-                        return results;
-                    }
+                    return Normalize(TransformObject(inputData));
             }
         }
     }

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -28,12 +28,12 @@ namespace PSWordCloud
 
         #region Constants
 
-        private const float FOCUS_WORD_SCALE = 1.3f;
-        private const float BLEED_AREA_SCALE = 1.15f;
+        private const float FOCUS_WORD_SCALE = 1.2f;
+        private const float BLEED_AREA_SCALE = 1.2f;
         private const float MIN_SATURATION_VALUE = 5f;
         private const float MIN_BRIGHTNESS_DISTANCE = 25f;
-        private const float MAX_WORD_WIDTH_PERCENT = 0.75f;
-        private const float PADDING_BASE_SCALE = 0.05f;
+        private const float MAX_WORD_WIDTH_PERCENT = 1.0f;
+        private const float PADDING_BASE_SCALE = 0.06f;
 
         internal const float STROKE_BASE_SCALE = 0.02f;
 
@@ -977,8 +977,7 @@ namespace PSWordCloud
         /// <returns>Returns a float value representing a conservative scaling value to apply to each word.</returns>
         private static float FontScale(SKRect space, float baseScale, float averageWordFrequency, int wordCount)
         {
-            return baseScale * (space.Height + space.Width)
-                / (8 * averageWordFrequency * wordCount);
+            return baseScale * Math.Max(space.Height, space.Width) / (averageWordFrequency * wordCount);
         }
 
         /// <summary>
@@ -991,8 +990,8 @@ namespace PSWordCloud
         private static float ScaleWordSize(
             float baseSize, float globalScale, IDictionary<string, float> scaleDictionary)
         {
-            return baseSize * globalScale * (2 * RandomFloat()
-                / (1 + scaleDictionary.Values.Max() - scaleDictionary.Values.Min()) + 0.9f);
+            return baseSize * globalScale * (((0.75f + RandomFloat()) / 2)
+                / (1 + scaleDictionary.Values.Max() - scaleDictionary.Values.Min()) + 0.68f);
         }
 
         /// <summary>
@@ -1020,7 +1019,7 @@ namespace PSWordCloud
         /// at that radius once again for available space.</returns>
         private static float GetRadiusIncrement(
             float wordSize, float distanceStep, float maxRadius, float padding, float percentComplete)
-            => (5 + RandomFloat() * (2.5f + percentComplete / 10)) * distanceStep * wordSize * (1 + padding) / maxRadius;
+            => (4 + RandomFloat() * (2.5f + percentComplete / 8)) * distanceStep * wordSize * (1 + padding) / maxRadius;
 
         /// <summary>
         /// Scans in an ovoid pattern at a given radius to get a set of points to check for sufficient drawing space.
@@ -1131,7 +1130,7 @@ namespace PSWordCloud
         {
             foreach (var word in text.Split(_splitChars, StringSplitOptions.RemoveEmptyEntries))
             {
-                yield return Regex.Replace(word, @"[^a-zA-Z0-9]\b|\b[^a-zA-Z0-9']", string.Empty);
+                yield return Regex.Replace(word, @"^[^a-zA-Z0-9]|[^a-zA-Z0-9']$", string.Empty);
             }
         }
 

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -892,7 +892,7 @@ namespace PSWordCloud
 
                     try
                     {
-                        value = LanguagePrimitives.ConvertTo<string>(input.BaseObject);
+                        value = LanguagePrimitives.ConvertTo<string>(input);
                     }
                     catch
                     {

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1019,7 +1019,7 @@ namespace PSWordCloud
         /// at that radius once again for available space.</returns>
         private static float GetRadiusIncrement(
             float wordSize, float distanceStep, float maxRadius, float padding, float percentComplete)
-            => (4 + RandomFloat() * (2.5f + percentComplete / 8)) * distanceStep * wordSize * (1 + padding) / maxRadius;
+            => (4 + RandomFloat() * (1 + percentComplete / 10)) * distanceStep * wordSize * (1 + padding) / maxRadius;
 
         /// <summary>
         /// Scans in an ovoid pattern at a given radius to get a set of points to check for sufficient drawing space.

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -827,18 +827,53 @@ namespace PSWordCloud
         private IEnumerable<string> NormalizeInput(PSObject input)
         {
             string value;
-            if (MyInvocation.ExpectingInput)
+            switch (input.BaseObject)
             {
-                if (input.BaseObject is string s)
-                {
-                    yield return s;
+                case string s2:
+                    yield return s2;
                     yield break;
-                }
-                else
-                {
+
+                case string[] sa:
+                    foreach (var line in sa)
+                    {
+                        yield return line;
+                    }
+
+                    yield break;
+
+                default:
+                    IEnumerable enumerable;
                     try
                     {
-                        value = LanguagePrimitives.ConvertTo<string>(input);
+                        enumerable = LanguagePrimitives.GetEnumerable(input.BaseObject);
+                    }
+                    catch
+                    {
+                        yield break;
+                    }
+
+                    if (enumerable != null)
+                    {
+                        foreach (var item in enumerable)
+                        {
+                            try
+                            {
+                                value = LanguagePrimitives.ConvertTo<string>(item);
+                            }
+                            catch
+                            {
+                                yield break;
+                            }
+
+                            yield return value;
+                        }
+
+                        yield break;
+                    }
+
+                    try
+                    {
+                        value = LanguagePrimitives.ConvertTo<string>(input.BaseObject);
                     }
                     catch
                     {
@@ -847,66 +882,6 @@ namespace PSWordCloud
 
                     yield return value;
                     yield break;
-                }
-            }
-            else
-            {
-                switch (input.BaseObject)
-                {
-                    case string[] sa:
-                        foreach (var line in sa)
-                        {
-                            yield return line;
-                        }
-
-                        yield break;
-
-                    case string s2:
-                        yield return s2;
-                        yield break;
-
-                    default:
-                        IEnumerable enumerable;
-                        try
-                        {
-                            enumerable = LanguagePrimitives.GetEnumerable(input.BaseObject);
-                        }
-                        catch
-                        {
-                            yield break;
-                        }
-
-                        if (enumerable != null)
-                        {
-                            foreach (var item in enumerable)
-                            {
-                                try
-                                {
-                                    value = LanguagePrimitives.ConvertTo<string>(item);
-                                }
-                                catch
-                                {
-                                    yield break;
-                                }
-
-                                yield return value;
-                            }
-
-                            yield break;
-                        }
-
-                        try
-                        {
-                            value = LanguagePrimitives.ConvertTo<string>(input.BaseObject);
-                        }
-                        catch
-                        {
-                            yield break;
-                        }
-
-                        yield return value;
-                        yield break;
-                }
             }
         }
 

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -77,7 +77,7 @@ namespace PSWordCloud
 
         internal static float SortValue(this SKColor color, float sortAdjustment)
         {
-            color.ToHsv(out float h, out float saturation, out float brightness);
+            color.ToHsv(out _, out float saturation, out float brightness);
             var rand = brightness * (sortAdjustment - 0.5f) / (1 - saturation);
             return brightness + rand;
         }

--- a/Tests/PSWordCloud.Tests.ps1
+++ b/Tests/PSWordCloud.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'PSWordCloud Tests' {
         }
 
         It 'should have SVG data in the file' {
-            Select-String -Pattern '<svg.*>'  -Path $FilePath | Should -Not -BeNullOrEmpty
+            Select-String -Pattern '<svg.*>'  -Path $File.FullName | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -39,7 +39,7 @@ Describe 'PSWordCloud Tests' {
         It 'should run New-WordCloud without errors' {
             Get-ChildItem -Path "$PSScriptRoot/../" -Recurse -File -Include "*.cs", "*.ps*1", "*.md" |
                 Get-Content |
-                New-WordCloud -Path "variable:\$VariableName"
+                New-WordCloud -Path "variable:global:$VariableName"
         }
 
         It 'should create a new variable' {

--- a/build/Build-Module.ps1
+++ b/build/Build-Module.ps1
@@ -15,13 +15,20 @@ param(
     $ProjectFile = (Join-Path -Path "$PSScriptRoot/.." -ChildPath "Module" "PSWordCloudCmdlet.csproj")
 )
 
+$Line = '-' * 50
+
 $PSVersionTable | Out-String | Write-Host
+
+Write-Host $Line
+Write-Host "Setup"
+Write-Host $Line
 
 Write-Host "Importing PlatyPS"
 Import-Module PlatyPS
 
 if (Test-Path -Path $OutputPath) {
     Write-Host "Cleaning up '$OutputPath'"
+
     Get-ChildItem -Path $OutputPath -Directory |
         Where-Object Name -in 'bin', 'PSWordCloud' |
         Remove-Item -Recurse
@@ -31,6 +38,9 @@ $ModulePath = Join-Path $OutputPath -ChildPath 'PSWordCloud'
 
 $SupportedPlatforms = "win-x64", "win-x86", "linux-x64", "osx"
 
+Write-Host $Line
+Write-Host "Compiling module with dotnet publish"
+Write-Host $Line
 foreach ($rid in $SupportedPlatforms) {
     $binPath = Join-Path -Path $OutputPath -ChildPath "bin"
     if (Test-Path $binPath) {
@@ -38,7 +48,7 @@ foreach ($rid in $SupportedPlatforms) {
     }
 
     Write-Host "Running 'dotnet publish' with RID: $rid"
-    $process = Start-Process -FilePath 'dotnet' -WindowStyle Hidden -PassThru -ArgumentList @(
+    $process = Start-Process -FilePath 'dotnet' -NoNewWindow -Wait -PassThru -ArgumentList @(
         'publish'
         "--configuration $Channel"
         "--output $binPath"
@@ -46,15 +56,8 @@ foreach ($rid in $SupportedPlatforms) {
         "--runtime $rid"
     )
 
-    try {
-        Write-Host "Waiting for dotnet process to exit..."
-        $process.WaitForExit()
-    }
-    catch {
-        Write-Warning "dotnet process errored on WaitForExit()"
-    }
-
     Write-Host "Locating 'libSkiaSharp' file for $rid"
+
     $nativeLib = Join-Path $OutputPath -ChildPath 'bin' |
         Get-ChildItem -Recurse -File -Filter '*libSkiaSharp*'
     $destinationPath = Join-Path $ModulePath -ChildPath $rid |
@@ -65,22 +68,34 @@ foreach ($rid in $SupportedPlatforms) {
     $nativeLib | Move-Item -Destination $destinationPath -Force -PassThru
 }
 
-Write-Host "Copying PSWordCloud and SkiaSharp DLLs to '$ModulePath'"
+Write-Host $Line
+Write-Host "Copying PSWordCloud and SkiaSharp Files to '$ModulePath'"
+Write-Host $Line
+
 Copy-Item -Path "$OutputPath/bin/PSWordCloudCmdlet.dll" -Destination $ModulePath
 Copy-Item -Path "$OutputPath/bin/SkiaSharp.dll" -Destination $ModulePath
 
-Write-Host "Copying PowerShell files to module folder"
+Write-Host "Copying script & metadata files to module folder"
+
 Split-Path -Path $ProjectFile -Parent |
     Get-ChildItem -Recurse -Include "*.ps*1" |
     Copy-Item -Destination $ModulePath
+
+Write-Host $Line
+Write-Host "Generating External Help"
+Write-Host $Line
 
 Write-Host "Importing the built module"
 Import-Module $ModulePath
 
 $DocsPath = Join-Path "$PSScriptRoot/.." -ChildPath "docs"
+
 Write-Host "Updating markdown help files in '$DocsPath'"
+
 Update-MarkdownHelp -Path $DocsPath -AlphabeticParamsOrder
 
 $ExternalHelpPath = Join-Path $ModulePath -ChildPath "en-US"
+
 Write-Host "Generating external help in '$ExternalHelpPath'"
+
 New-ExternalHelp -Path $DocsPath -OutputPath $ExternalHelpPath

--- a/build/Build-Module.ps1
+++ b/build/Build-Module.ps1
@@ -48,13 +48,15 @@ foreach ($rid in $SupportedPlatforms) {
     }
 
     Write-Host "Running 'dotnet publish' with RID: $rid"
-    $process = Start-Process -FilePath 'dotnet' -NoNewWindow -Wait -PassThru -ArgumentList @(
+    $process = Start-Process -FilePath 'dotnet' -NoNewWindow -PassThru -ArgumentList @(
         'publish'
         "--configuration $Channel"
         "--output $binPath"
         $ProjectFile
         "--runtime $rid"
     )
+
+    $process.WaitForExit()
 
     Write-Host "Locating 'libSkiaSharp' file for $rid"
 


### PR DESCRIPTION
# PR Summary

+ Use `LanguagePrimitives.ConvertTo<string>()` to convert input objects, being sure to check if directly-supplied input objects are iterable and converting them as appropriate. This change should fix #24.
+ A few  style changes recommended by the Roslyn analyser.
+ Added support for output to any PSProvider via the -Path parameter. This includes things like the `variable:` provider -- if it has a PSDrive associated with it and it supports the Set-Content command, New-WordCloud can write the SVG data to it.
+ Tweak the word splitting/trimming methods so we don't get odd leading characters being considered part of the word.
+ Add tasks.json for easier debugging in VS Code
+ Reformat build script to make the logging output more clear.