### PR TITLE
Add -WordSizes parameter and cleanup

### DIFF
--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -527,9 +527,6 @@ namespace PSWordCloud
                     }
 
                     break;
-
-                default:
-                    break;
             }
         }
 

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -672,7 +672,9 @@ namespace PSWordCloud
                         foreach (string word in sortedWordList)
                         {
                             adjustedWordSize = ScaleWordSize(
-                                wordScaleDictionary[word], _fontScale, wordScaleDictionary);
+                                wordScaleDictionary[word],
+                                _fontScale,
+                                wordScaleDictionary);
 
                             brush.NextWord(adjustedWordSize, StrokeWidth);
 
@@ -769,7 +771,10 @@ namespace PSWordCloud
 
                         wordProgress.StatusDescription = string.Format(
                             "Draw: \"{0}\" [Size: {1:0}] ({2} of {3})",
-                            word, brush.TextSize, wordCount, scaledWordSizes.Count);
+                            word,
+                            brush.TextSize,
+                            wordCount,
+                            scaledWordSizes.Count);
                         wordProgress.PercentComplete = (int)Math.Round(percentComplete);
                         WriteProgress(wordProgress);
 
@@ -777,7 +782,11 @@ namespace PSWordCloud
                             float radius = 0;
                             radius <= maxRadius;
                             radius += GetRadiusIncrement(
-                                scaledWordSizes[word], DistanceStep, maxRadius, inflationValue, percentComplete))
+                                scaledWordSizes[word],
+                                DistanceStep,
+                                maxRadius,
+                                inflationValue,
+                                percentComplete))
                         {
                             SKPoint adjustedPoint, baseOffset;
 
@@ -797,7 +806,11 @@ namespace PSWordCloud
                                     drawAngle);
                                 pointProgress.StatusDescription = string.Format(
                                     "Checking [Point:{0,8:N2}, {1,8:N2}] ({2,4} / {3,4}) at [Radius: {4,8:N2}]",
-                                    point.X, point.Y, pointsChecked, totalPoints, radius);
+                                    point.X,
+                                    point.Y,
+                                    pointsChecked,
+                                    totalPoints,
+                                    radius);
                                 // pointProgress.PercentComplete = 100 * pointsChecked / totalPoints;
                                 WriteProgress(pointProgress);
 

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1027,7 +1027,11 @@ namespace PSWordCloud
         /// brightness values.</param>
         /// <returns></returns>
         private static IEnumerable<SKColor> ProcessColorSet(
-            SKColor[] set, SKColor background, SKColor stroke, int maxCount, bool monochrome)
+            SKColor[] set,
+            SKColor background,
+            SKColor stroke,
+            int maxCount,
+            bool monochrome)
         {
             Shuffle(set);
             background.ToHsv(out float bh, out float bs, out float backgroundBrightness);
@@ -1257,7 +1261,9 @@ namespace PSWordCloud
         /// <param name="line">The text to split and process.</param>
         /// <returns>An enumerable string collection of all words in the input, with stopwords stripped out.</returns>
         private Task<IEnumerable<string>> ProcessInputAsync(
-            string line, string[] includeWords = null, string[] excludeWords = null)
+            string line,
+            string[] includeWords = null,
+            string[] excludeWords = null)
         {
             return Task.Run<IEnumerable<string>>(
                 () => TrimAndSplitWords(line).Where(x => SelectWord(x, includeWords, excludeWords)));

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -587,7 +587,7 @@ namespace PSWordCloud
                         }
                         catch (Exception e)
                         {
-                            throw e;
+                            WriteWarning($"Skipping entry '{word}' due to error converting key or value: {e.Message}.");
                         }
                     }
 

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -537,7 +537,11 @@ namespace PSWordCloud
         protected override void EndProcessing()
         {
             int wordCount = 0;
-            float inflationValue, maxWordWidth, highestWordFreq, aspectRatio, maxRadius;
+            float inflationValue;
+            float maxWordWidth;
+            float highestWordFreq;
+            float aspectRatio;
+            float maxRadius;
 
             SKPath wordPath = null;
             SKRegion clipRegion = null;
@@ -546,7 +550,8 @@ namespace PSWordCloud
             SKBitmap backgroundImage = null;
             SKPoint centrePoint;
             List<string> sortedWordList;
-            ProgressRecord wordProgress = null, pointProgress = null;
+            ProgressRecord wordProgress = null;
+            ProgressRecord pointProgress = null;
 
             Dictionary<string, float> scaledWordSizes;
             var wordScaleDictionary = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
@@ -623,7 +628,8 @@ namespace PSWordCloud
                     Typeface);
 
                 scaledWordSizes = new Dictionary<string, float>(
-                    sortedWordList.Count, StringComparer.OrdinalIgnoreCase);
+                    sortedWordList.Count,
+                    StringComparer.OrdinalIgnoreCase);
 
                 maxWordWidth = AllowRotation == WordOrientations.None
                     ? drawableBounds.Width * MAX_WORD_WIDTH_PERCENT
@@ -641,10 +647,16 @@ namespace PSWordCloud
                         // Pre-test and adjust global scale based on the largest word.
                         retry = false;
                         adjustedWordSize = ScaleWordSize(
-                            wordScaleDictionary[sortedWordList[0]], _fontScale, wordScaleDictionary);
+                            wordScaleDictionary[sortedWordList[0]],
+                            _fontScale,
+                            wordScaleDictionary);
+
                         brush.NextWord(adjustedWordSize, StrokeWidth);
-                        var adjustedTextWidth = brush.MeasureText(sortedWordList[0], ref rect) * (1 + _paddingMultiplier);
-                        if ((rect.Width * rect.Height * 8) < (drawableBounds.Width * drawableBounds.Height * 0.75f))
+
+                        var textRect = brush.GetTextPath(sortedWordList[0], 0, 0).ComputeTightBounds();
+                        var adjustedTextWidth = textRect.Width * (1 + _paddingMultiplier) + StrokeWidth * 2 * STROKE_BASE_SCALE;
+                        if (adjustedTextWidth > maxWordWidth
+                                || textRect.Width * textRect.Height < drawableBounds.Width * drawableBounds.Height * MAX_WORD_AREA_PERCENT)
                         {
                             retry = true;
                             _fontScale *= 1.05f;

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -106,7 +106,8 @@ namespace PSWordCloud
         [Parameter(Mandatory = true, ParameterSetName = COLOR_BG_FOCUS_TABLE_SET)]
         [Parameter(Mandatory = true, ParameterSetName = FILE_TABLE_SET)]
         [Parameter(Mandatory = true, ParameterSetName = FILE_FOCUS_TABLE_SET)]
-        public IDictionary WordSizeTable { get; set; }
+        [Alias("WordSizeTable", "CustomWordSizes")]
+        public IDictionary WordSizes { get; set; }
 
         /// <summary>
         /// Gets or sets the output path to save the final SVG vector file to.
@@ -574,13 +575,13 @@ namespace PSWordCloud
                 case FILE_FOCUS_TABLE_SET:
                 case COLOR_BG_TABLE_SET:
                 case COLOR_BG_FOCUS_TABLE_SET:
-                    foreach (var word in WordSizeTable.Keys)
+                    foreach (var word in WordSizes.Keys)
                     {
                         try
                         {
                             wordScaleDictionary.Add(
                                 LanguagePrimitives.ConvertTo<string>(word),
-                                LanguagePrimitives.ConvertTo<float>(WordSizeTable[word]));
+                                LanguagePrimitives.ConvertTo<float>(WordSizes[word]));
                         }
                         catch (Exception e)
                         {

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -91,6 +91,16 @@ namespace PSWordCloud
         [AllowEmptyString()]
         public PSObject InputObject { get; set; }
 
+        /// <summary>
+        /// Instead of supplying a chunk of text as the input, this parameter allows you to define your own relative
+        /// word sizes.
+        /// Supply a dictionary or hashtable object where the keys are the words you want to draw in the cloud, and the
+        /// values are their relative sizes.
+        /// Words will be scaled as a percentage of the largest sized word in the table.
+        /// In other words, if you have @{ text = 10; image = 100 }, then "text" will appear 10 times smaller than
+        /// "image".
+        /// </summary>
+        /// <value></value>
         [Parameter(Mandatory = true, ParameterSetName = COLOR_BG_TABLE_SET)]
         [Parameter(Mandatory = true, ParameterSetName = COLOR_BG_FOCUS_TABLE_SET)]
         [Parameter(Mandatory = true, ParameterSetName = FILE_TABLE_SET)]

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -35,6 +35,11 @@ namespace PSWordCloud
             return (float)(degrees * Math.PI / 180);
         }
 
+        /// <summary>
+        /// Returns a font scale value based on the size of the letter X in a given typeface.
+        /// </summary>
+        /// <param name="typeface">The typeface to measure the scale from.</param>
+        /// <returns>A float value typically between 0 and 1. Many common typefaces have values around 0.5.</returns>
         internal static float GetFontScale(SKTypeface typeface)
         {
             var text = "X";

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -35,6 +35,19 @@ namespace PSWordCloud
             return (float)(degrees * Math.PI / 180);
         }
 
+        internal static float GetFontScale(SKTypeface typeface)
+        {
+            var text = "X";
+            using (var paint = new SKPaint())
+            {
+                paint.Typeface = typeface;
+                paint.TextSize = 1;
+                var rect = paint.GetTextPath(text, 0, 0).ComputeTightBounds();
+
+                return (rect.Width + rect.Height) / 2;
+            }
+        }
+
         internal static void Shuffle<T>(this Random rng, T[] array)
         {
             int n = array.Length;

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -54,7 +54,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
 
 ### ColorBackground-WordTable
 ```
-New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
+New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>]
  [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
@@ -64,7 +64,7 @@ New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI
 
 ### ColorBackground-FocusWord-WordTable
 ```
-New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
+New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  -FocusWord <String> [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
  [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>]
@@ -74,7 +74,7 @@ New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI
 
 ### FileBackground-WordTable
 ```
-New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
+New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-ExcludeWord <String[]>]
  [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
@@ -83,7 +83,7 @@ New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> -BackgroundImage <St
 
 ### FileBackground-FocusWord-WordTable
 ```
-New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
+New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
  [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>]
@@ -655,7 +655,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WordSizeTable
+### -WordSizes
 
 Instead of supplying a chunk of text as the input, this parameter allows you to define your own relative word sizes.
 Supply a dictionary or hashtable object where the keys are the words you want to draw in the cloud, and the values are their relative sizes.
@@ -665,7 +665,7 @@ In other words, if you have @{ text = 10; image = 100 }, then "text" will appear
 ```yaml
 Type: IDictionary
 Parameter Sets: ColorBackground-WordTable, ColorBackground-FocusWord-WordTable, FileBackground-WordTable, FileBackground-FocusWord-WordTable
-Aliases:
+Aliases: WordSizeTable, CustomWordSizes
 
 Required: True
 Position: Named

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -52,6 +52,45 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
  [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
+### ColorBackground-WordTable
+```
+New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
+ [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
+ [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>]
+ [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru]
+ [<CommonParameters>]
+```
+
+### ColorBackground-FocusWord-WordTable
+```
+New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
+ [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
+ -FocusWord <String> [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
+ [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>]
+ [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome]
+ [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
+```
+
+### FileBackground-WordTable
+```
+New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
+ [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-ExcludeWord <String[]>]
+ [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>]
+ [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
+ [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
+```
+
+### FileBackground-FocusWord-WordTable
+```
+New-WordCloud -WordSizeTable <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
+ [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
+ [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
+ [-AllowRotation <WordOrientations>] [-Padding <Single>] [-DistanceStep <Single>] [-RadialStep <Single>]
+ [-MaxRenderedWords <Int32>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords]
+ [-AllowOverflow] [-PassThru] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 New-WordCloud takes input text either over the pipeline or directly to its -InputObject parameter,
@@ -204,7 +243,7 @@ Accepts input as a complete SKColor object, or one of the following formats:
 
 ```yaml
 Type: SKColor
-Parameter Sets: ColorBackground, ColorBackground-FocusWord
+Parameter Sets: ColorBackground, ColorBackground-FocusWord, ColorBackground-WordTable, ColorBackground-FocusWord-WordTable
 Aliases: Backdrop, CanvasColor
 
 Required: False
@@ -220,7 +259,7 @@ Specifies the path to the background image to be used as a base for the final wo
 
 ```yaml
 Type: String
-Parameter Sets: FileBackground, FileBackground-FocusWord
+Parameter Sets: FileBackground, FileBackground-FocusWord, FileBackground-WordTable, FileBackground-FocusWord-WordTable
 Aliases:
 
 Required: True
@@ -295,7 +334,7 @@ the centre of the cloud, larger than all the other words.
 
 ```yaml
 Type: String
-Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord
+Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord, ColorBackground-FocusWord-WordTable, FileBackground-FocusWord-WordTable
 Aliases: Title
 
 Required: True
@@ -326,7 +365,7 @@ Input can be passed directly as a [SkiaSharp.SKSizeI] object, or in one of the f
 
 ```yaml
 Type: SKSizeI
-Parameter Sets: ColorBackground, ColorBackground-FocusWord
+Parameter Sets: ColorBackground, ColorBackground-FocusWord, ColorBackground-WordTable, ColorBackground-FocusWord-WordTable
 Aliases:
 
 Required: False
@@ -362,7 +401,7 @@ If you are entering complex object input, ensure the objects have a meaningful T
 
 ```yaml
 Type: PSObject
-Parameter Sets: (All)
+Parameter Sets: ColorBackground, ColorBackground-FocusWord, FileBackground, FileBackground-FocusWord
 Aliases: InputString, Text, String, Words, Document, Page
 
 Required: True
@@ -516,7 +555,7 @@ Values from -360 to 360, including sub-degree increments, are permitted.
 
 ```yaml
 Type: Single
-Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord
+Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord, ColorBackground-FocusWord-WordTable, FileBackground-FocusWord-WordTable
 Aliases: RotateTitle
 
 Required: False
@@ -612,6 +651,25 @@ Aliases: ScaleFactor
 Required: False
 Position: Named
 Default value: 1.0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WordSizeTable
+
+Instead of supplying a chunk of text as the input, this parameter allows you to define your own relative word sizes.
+Supply a dictionary or hashtable object where the keys are the words you want to draw in the cloud, and the values are their relative sizes.
+Words will be scaled as a percentage of the largest sized word in the table.
+In other words, if you have @{ text = 10; image = 100 }, then "text" will appear 10 times smaller than "image".
+
+```yaml
+Type: IDictionary
+Parameter Sets: ColorBackground-WordTable, ColorBackground-FocusWord-WordTable, FileBackground-WordTable, FileBackground-FocusWord-WordTable
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
This parameter allows users to create "custom" word clouds by directly specifying a set of words and their relative sizes.

+ Added parameter for `-WordSizes`
+ Added documentation for parameter & new sets.
+ Tweaking algorithms for word sizing and placement & making them more readable.