### PR TITLE
Enable Mac OS tests

### DIFF
--- a/Tests/PSWordCloud.Tests.ps1
+++ b/Tests/PSWordCloud.Tests.ps1
@@ -1,8 +1,11 @@
 Describe 'PSWordCloud Tests' {
 
     BeforeAll {
-        $File = New-TemporaryFile |
-            Rename-Item -NewName { "$($_.BaseName).svg" } -PassThru
+        $FileName = New-TemporaryFile |
+            Rename-Item -NewName { "$($_.BaseName).svg" } -PassThru |
+            Select-Object -ExpandProperty FullName
+
+        Remove-Item -Path $FileName -Force
     }
 
     It 'should be able to import the PSWordCloud module successfully' {
@@ -13,20 +16,20 @@ Describe 'PSWordCloud Tests' {
         It 'should run New-WordCloud without errors' {
             Get-ChildItem -Path "$PSScriptRoot/../" -Recurse -File -Include "*.cs", "*.ps*1", "*.md" |
                 Get-Content |
-                New-WordCloud -Path $File.FullName
+                New-WordCloud -Path $FileName
         }
 
         It 'should create a new SVG file' {
-            $File | Should -Exist
+            $FileName | Should -Exist
         }
 
         It 'should create a non-empty file' {
-            $File = Get-Item -Path $File.FullName
-            $File.Length | Should -BeGreaterThan 0
+            $FileName = Get-Item -Path $FileName
+            (Get-Item -Path $FileName).Length | Should -BeGreaterThan 0
         }
 
         It 'should have SVG data in the file' {
-            Select-String -Pattern '<svg.*>'  -Path $File.FullName | Should -Not -BeNullOrEmpty
+            Select-String -Pattern '<svg.*>' -Path $FileName | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,9 +165,6 @@ stages:
   dependsOn:
   - Build
 
-  # DISABLED: MacOS Runner does not have PS7 installed currently.
-  condition: false
-
   jobs:
   - job: MacOS
     displayName: 'Pester Tests'

--- a/build/Build-Module.ps1
+++ b/build/Build-Module.ps1
@@ -62,12 +62,24 @@ foreach ($rid in $SupportedPlatforms) {
 
     $nativeLib = Join-Path $OutputPath -ChildPath 'bin' |
         Get-ChildItem -Recurse -File -Filter '*libSkiaSharp*'
+
+    <#
+        SkiaSharp designates the 'osx' RID, but pwsh only recognises the
+        'osx-64' RID when looking for native library folders in the module
+        directory.
+    #>
+    if ($rid -eq 'osx') {
+        $rid = 'osx-x64'
+    }
+
     $destinationPath = Join-Path $ModulePath -ChildPath $rid |
         New-Item -Path { $_ } -ItemType Directory |
         Select-Object -ExpandProperty FullName
 
     Write-Host "Moving $nativeLib to $destinationPath"
-    $nativeLib | Move-Item -Destination $destinationPath -Force -PassThru
+    $nativeLib = $nativeLib | Move-Item -Destination $destinationPath -Force -PassThru
+
+    $nativeLib
 }
 
 Write-Host $Line


### PR DESCRIPTION
Azure Pipelines' Mac agents now have pwsh 7.0.0, so it's safe to enable these tests.

Needed to adjust build script slightly to ensure the dylib goes into the correct folder, but otherwise everything seems to work smoothly.