### PR TITLE
Overflow Fixes & Retry if a given rotation is unsuitable

### DIFF
--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1050,7 +1050,8 @@ namespace PSWordCloud
         /// </summary>
         private static IEnumerable<float> RandomAngles(int minAngle, int maxAngle)
         {
-            for (var i = 0; i < RandomInt(4, 16); i++)
+            var angleCount = RandomInt(4, 12);
+            for (var i = 0; i < angleCount; i++)
             {
                 yield return RandomFloat(minAngle, maxAngle);
             }

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -103,7 +103,7 @@ namespace PSWordCloud
         /// <param name="rng">Random number generator.</param>
         /// <param name="array">The array to shuffle.</param>
         /// <typeparam name="T">The element type of the array.</typeparam>
-        internal static void Shuffle<T>(this Random rng, T[] array)
+        internal static T[] Shuffle<T>(this Random rng, T[] array)
         {
             int n = array.Length;
             while (n > 1)
@@ -113,6 +113,8 @@ namespace PSWordCloud
                 array[n] = array[k];
                 array[k] = temp;
             }
+
+            return array;
         }
 
         /// <summary>

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -133,6 +133,19 @@ namespace PSWordCloud
         }
 
         /// <summary>
+        /// Checks if the given <paramref name="point"/> lies somewhere inside the <paramref name="region"/>.
+        /// </summary>
+        /// <param name="region">The region that defines the bounds.</param>
+        /// <param name="point">The point to check.</param>
+        /// <returns></returns>
+        internal static bool Contains(this SKRegion region, SKPoint point)
+        {
+            SKRectI bounds = region.Bounds;
+            return bounds.Left < point.X && point.X < bounds.Right
+                && bounds.Top < point.Y && point.Y < bounds.Bottom;
+        }
+
+        /// <summary>
         /// Prepares the brush to draw the next word.
         /// This overload assumes the text to be drawn will be black.
         /// </summary>

--- a/PSWordCloud.Tests/PSWordCloud.Tests.csproj
+++ b/PSWordCloud.Tests/PSWordCloud.Tests.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Module\PSWordCloudCmdlet.csproj" />
 
+<ItemGroup>
+  <ProjectReference Include="..\PSWordCloudCmdlet.csproj" />
 </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="2.0.1" />
-
   </ItemGroup>
 
 </Project>

--- a/build/Build-Module.ps1
+++ b/build/Build-Module.ps1
@@ -77,7 +77,7 @@ foreach ($rid in $SupportedPlatforms) {
         Select-Object -ExpandProperty FullName
 
     Write-Host "Moving $nativeLib to $destinationPath"
-    $nativeLib = $nativeLib | Move-Item -Destination $destinationPath -Force -PassThru
+    $nativeLib = $nativeLib | Copy-Item -Destination $destinationPath -Force -PassThru
 
     $nativeLib
 }


### PR DESCRIPTION
# PR Summary

## Retry with alternate angles

- Pre-generate a short randomized list of possible angles for the word to be drawn at.
- If no drawable location for the word at the current orientation is found, the list of angles will be used to retry the draw operation. In other words, the placement algorithm now operates like this:
  1. Start at the center, scan a set of radial points until either a placement is found or the set of points is exhausted.
  2. Widen the radius and repeat, until the maximum radius is reached.
  3. If no placement has been found, change rotation to the next in the list and restart the scan from the center.
  4. If not placement is found, write a warning saying as much and skip to the next word.

##  Fix overflow behaviour

+ Increased bleed area scale from 1.2 to 1.5
+ Apply bleed/overflow scaling to the clipRegion so we don't discard possible locations that exceed image bounds (i.e., that switch actually does what it says on the tin now)
+ Apply bleed/overflow scaling to maximum search radius.
+ Remove unneeded 'drawableBounds' SKRect.
+ Add helper method for SKRegion to determine if point is within it.

## Misc Changes

+ Changed `WCUtils.Shuffle()` and `NewWordCloudCmdlet.Shuffle()` to both return a reference to the shuffled array. This allows us to do `Random.Shuffle(new[] { ... });` and store that result rather than needing to pre-define the variable.
+ Removed `NewWordCloudCmdlet.RandomChoice()` as it was no longer needed
+ Added a new overload for `NewWordCloudCmdlet.RandomFloat()` to specify upper and lower bounds.