### PR TITLE
Use distance to corner for maxRadius

### DIFF
--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -686,7 +686,8 @@ namespace PSWordCloud
                 // Remove all words that were cut from the final rendering list
                 sortedWordList.RemoveAll(x => !scaledWordSizes.ContainsKey(x));
 
-                maxRadius = 9 * Math.Max(viewbox.Width, viewbox.Height) / 16f;
+                // Max radius should reach to the corner of the image; location is top-left of the box
+                maxRadius = SKPoint.Distance(viewbox.Location, centrePoint);
 
                 if (AllowOverflow)
                 {


### PR DESCRIPTION
Currently we use the largest side length with a slight additional bleed to try to cover the corners of the image, since we scan in a circular pattern.

Instead, we can just measure the distance from the center to the corner of the image for the maxRadius value.