### PR TITLE
Refactor Word Positioning

### DIFF
--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -772,8 +772,8 @@ namespace PSWordCloud
                         wordPath = brush.GetTextPath(word, 0, 0);
                         wordBounds = wordPath.TightBounds;
 
-                        var wordWidth = wordBounds.Width;
-                        var wordHeight = wordBounds.Height;
+                        SKMatrix rotation = SKMatrix.MakeRotationDegrees(drawAngle, wordBounds.MidX, wordBounds.MidY);
+                        wordPath.Transform(rotation);
 
                         for (
                             float radius = 0;
@@ -812,10 +812,7 @@ namespace PSWordCloud
 
                                 var pathMidpoint = new SKPoint(wordBounds.MidX, wordBounds.MidY);
 
-                                SKMatrix rotation = SKMatrix.MakeRotationDegrees(drawAngle, point.X, point.Y);
-
                                 wordPath.Offset(point - pathMidpoint);
-                                wordPath.Transform(rotation);
                                 wordBounds = wordPath.TightBounds;
 
                                 wordBounds.Inflate(inflationValue, inflationValue);


### PR DESCRIPTION
# :memo: PR Summary

Currently we use a bit of janky math to try to position the words by their centrepoint. We can just... actually use the defined centrepoint of the word and use that to figure out where to move it.

## :books: Context

Just stumbled across this method while working on something else and it seems like a much simpler method to work with.

## :wrench: Changes

- Use just one SKPath per rotation of each word, rather than 1 for the base word + 1 for each rotation/positioning.
- Position the original wordPath rather than making a new path to position.
- Use the word path's current centre and the target point to calculate the offset.
- Use `SKPath.Offset()` rather than `SKPath.Transform()` to avoid needing a matrix for that operation.
- Update references to `adjustedPath` to just use the original `wordPath`.
- Apply rotation only once per path, immediately after rotation is selected.

### Example Cloud

#### Settings
```ps1
$text | New-WordCloud -Path ./test.svg -ImageSize 1080p -BackgroundColor White -StrokeWidth 1 -PassThru -MaxRenderedWords 200 -FocusWord Koan -Padding 3
```

#### Result

[![word cloud, 200 words, mostly default settings](https://cdn-31.anonfile.com/17b0x1j1o7/70399db5-1585110072/test.svg)](https://anonfile.com/17b0x1j1o7/test_svg)

## :clipboard: Checklist

+ [x] :warning: Pull Request has a meaningful title.
+ [x] :memo: Filled out the template above.
+ [x] :arrow_forward: Pull Request is ready to merge & is not WIP.
+ [x] :white_check_mark: **Tests** (select one)
  + [ ] :heavy_plus_sign: Added or updated tests.
  + [x] :video_game: Only testable interactively.

+ [x] :book: **Documentation** (select one)
  + [ ] :page_facing_up: Added documentation.
  + [ ] :bookmark: Created issue to add documentation later:
    + Issue #__
  + [x] :warning: None required
