### PR TITLE
Cleanup IEnumerable Usages

### DIFF
--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1323,7 +1323,7 @@ namespace PSWordCloud
 
             bool clockwise = RandomFloat() > 0.5;
 
-            float angle = RandomInt() % 4 switch
+            float angle = RandomInt(0, 4) switch
             {
                 1 => 90,
                 2 => 180,

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -320,7 +320,7 @@ namespace PSWordCloud
 
         internal static SKFontManager FontManager = SKFontManager.Default;
 
-        internal static IEnumerable<string> FontList = WCUtils.FontManager.FontFamilies
+        internal static IOrderedEnumerable<string> FontList = WCUtils.FontManager.FontFamilies
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
 
         internal static ReadOnlyDictionary<string, (string Tooltip, SKSizeI Size)> StandardImageSizes =


### PR DESCRIPTION
# :memo: PR Summary

@SeeminglyScience, circa 2020:

> `yield` is bad

Removing unnecessary `yield` and `IEnumerable` iterator patterns to clean things up and make behaviour more reliable.

## :books: Context

We were doing a double iteration of the angles being processed per radius, which a) gave us a misleading progress bar anyway, and b) just wasn't needed. While fixing that, I figured we can cut out a few more usages of IEnumerable just to be safe.

## :wrench: Changes

- Re-typed a bunch of methods to return either `List<T>` or `T[]` as appropriate instead of `IEnumerable<T>`.
- Refactored methods to avoid `yield return` etc., where it wasn't needed.
- Some minor refactoring while I was in the neighbourhood.

## :clipboard: Checklist

+ [x] :warning: Pull Request has a meaningful title.
+ [x] :memo: Filled out the template above.
+ [x] :arrow_forward: Pull Request is ready to merge & is not WIP.
+ [x] :white_check_mark: **Tests** (select one)
  + [ ] :heavy_plus_sign: Added or updated tests.
  + [x] :video_game: Only testable interactively.

+ [x] :book: **Documentation** (select one)
  + [ ] :page_facing_up: Added documentation.
  + [ ] :bookmark: Created issue to add documentation later:
    + Issue #__
  + [x] :warning: None required
