### PR TITLE
Major EndProcessing() Refactor

### DIFF
--- a/Module/src/PSWordCloud/Attributes.cs
+++ b/Module/src/PSWordCloud/Attributes.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -406,5 +406,4 @@ namespace PSWordCloud
             }
         }
     }
-
 }

--- a/Module/src/PSWordCloud/Attributes.cs
+++ b/Module/src/PSWordCloud/Attributes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -137,8 +137,8 @@ namespace PSWordCloud
                     if (properties.GetValue("Width") != null && properties.GetValue("Height") != null)
                     {
                         // If these conversions fail, the exception will cause the transform to fail.
-                        var width = LanguagePrimitives.ConvertTo<int>(properties.GetValue("Width"));
-                        var height = LanguagePrimitives.ConvertTo<int>(properties.GetValue("Height"));
+                        var width = properties.GetValue("Width").ConvertTo<int>();
+                        var height = properties.GetValue("Height").ConvertTo<int>();
 
                         return new SKSizeI(width, height);
                     }
@@ -216,15 +216,15 @@ namespace PSWordCloud
             {
                 SKFontStyleWeight weight = properties.GetValue("FontWeight") == null
                     ? SKFontStyleWeight.Normal
-                    : LanguagePrimitives.ConvertTo<SKFontStyleWeight>(properties.GetValue("FontWeight"));
+                    : properties.GetValue("FontWeight").ConvertTo<SKFontStyleWeight>();
 
                 SKFontStyleSlant slant = properties.GetValue("FontSlant") == null
                     ? SKFontStyleSlant.Upright
-                    : LanguagePrimitives.ConvertTo<SKFontStyleSlant>(properties.GetValue("FontSlant"));
+                    : properties.GetValue("FontSlant").ConvertTo<SKFontStyleSlant>();
 
                 SKFontStyleWidth width = properties.GetValue("FontWidth") == null
                     ? SKFontStyleWidth.Normal
-                    : LanguagePrimitives.ConvertTo<SKFontStyleWidth>(properties.GetValue("FontWidth"));
+                    : properties.GetValue("FontWidth").ConvertTo<SKFontStyleWidth>();
 
                 style = new SKFontStyle(weight, width, slant);
             }
@@ -235,7 +235,7 @@ namespace PSWordCloud
                     : SKFontStyle.Normal;
             }
 
-            string familyName = LanguagePrimitives.ConvertTo<string>(properties.GetValue("FamilyName"));
+            string familyName = properties.GetValue("FamilyName").ConvertTo<string>();
             return WCUtils.FontManager.MatchFamily(familyName, style);
         }
 
@@ -303,19 +303,19 @@ namespace PSWordCloud
 
                 byte red = properties.GetValue("red") == null
                     ? (byte)0
-                    : LanguagePrimitives.ConvertTo<byte>(properties.GetValue("red"));
+                    : properties.GetValue("red").ConvertTo<byte>();
 
                 byte green = properties.GetValue("green") == null
                     ? (byte)0
-                    : LanguagePrimitives.ConvertTo<byte>(properties.GetValue("green"));
+                    : properties.GetValue("green").ConvertTo<byte>();
 
                 byte blue = properties.GetValue("blue") == null
                     ? (byte)0
-                    : LanguagePrimitives.ConvertTo<byte>(properties.GetValue("blue"));
+                    : properties.GetValue("blue").ConvertTo<byte>();
 
                 byte alpha = properties.GetValue("alpha") == null
                     ? (byte)255
-                    : LanguagePrimitives.ConvertTo<byte>(properties.GetValue("alpha"));
+                    : properties.GetValue("alpha").ConvertTo<byte>();
 
                 colorList.Add(new SKColor(red, green, blue, alpha));
             }
@@ -401,7 +401,7 @@ namespace PSWordCloud
         {
             for (float angle = 0; angle <= 360; angle += 45)
             {
-                var s = LanguagePrimitives.ConvertTo<string>(angle);
+                var s = angle.ConvertTo<string>();
                 yield return new CompletionResult(s, s, CompletionResultType.ParameterValue, s);
             }
         }

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1019,7 +1019,7 @@ namespace PSWordCloud
             {
                 result = GetNextColor();
             }
-            while (!result.IsDistinctColor(reference));
+            while (!result.IsDistinctFrom(reference));
 
             return result;
         }

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -1155,7 +1155,7 @@ namespace PSWordCloud
                         {
                             try
                             {
-                                value = LanguagePrimitives.ConvertTo<string>(item);
+                                value = item.ConvertTo<string>();
                             }
                             catch
                             {
@@ -1170,7 +1170,7 @@ namespace PSWordCloud
 
                     try
                     {
-                        value = LanguagePrimitives.ConvertTo<string>(input);
+                        value = input.ConvertTo<string>();
                     }
                     catch
                     {

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -700,12 +700,12 @@ namespace PSWordCloud
                 backgroundImage?.Dispose();
 
                 // Write 'Completed' progress record
-                WriteProgress(new ProgressRecord(_progressId, string.Empty, string.Empty)
+                WriteProgress(new ProgressRecord(_progressId, "Completed", "Completed")
                 {
                     RecordType = ProgressRecordType.Completed
                 });
 
-                WriteProgress(new ProgressRecord(_progressId + 1, string.Empty, string.Empty)
+                WriteProgress(new ProgressRecord(_progressId + 1, "Completed", "Completed")
                 {
                     RecordType = ProgressRecordType.Completed
                 });

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -73,6 +73,29 @@ namespace PSWordCloud
             => LanguagePrimitives.ConvertTo<TResult>(item);
 
         /// <summary>
+        /// Perform an in-place-modification operation on every element in the array.
+        /// </summary>
+        /// <param name="items">The array to operate on.</param>
+        /// <returns>The transformed array.</returns>
+        public static T[] TransformElements<T>(this T[] items, Func<T, T> operation)
+        {
+            for (var index = 0; index < items.Length; index++)
+            {
+                items[index] = operation.Invoke(items[index]);
+            }
+
+            return items;
+        }
+
+        public static SKColor AsMonochrome(this SKColor color)
+        {
+            color.ToHsv(out _, out _, out float brightness);
+            byte level = (byte)Math.Floor(255 * brightness / 100f);
+
+            return new SKColor(level, level, level);
+        }
+
+        /// <summary>
         /// Determines whether a given color is considered sufficiently visually distinct from a backdrop color.
         /// </summary>
         /// <param name="target">The target color.</param>
@@ -113,9 +136,9 @@ namespace PSWordCloud
         /// <param name="rng">Random number generator.</param>
         /// <param name="array">The array to shuffle.</param>
         /// <typeparam name="T">The element type of the array.</typeparam>
-        internal static T[] Shuffle<T>(this Random rng, T[] array)
+        internal static IList<T> Shuffle<T>(this Random rng, IList<T> array)
         {
-            int n = array.Length;
+            int n = array.Count;
             while (n > 1)
             {
                 int k = rng.Next(n--);

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -63,6 +63,16 @@ namespace PSWordCloud
         }
 
         /// <summary>
+        /// Utility method which is just a convenient shortcut to <see cref="LanguagePrimitives.ConvertTo{T}(object)"/>.
+        /// </summary>
+        /// <param name="item">The object to convert.</param>
+        /// <typeparam name="TSource">The original object type.</typeparam>
+        /// <typeparam name="TResult">The resulting destination type.</typeparam>
+        /// <returns>The converted value.</returns>
+        public static TResult ConvertTo<TResult>(this object item)
+            => LanguagePrimitives.ConvertTo<TResult>(item);
+
+        /// <summary>
         /// Determines whether a given color is considered sufficiently visually distinct from a backdrop color.
         /// </summary>
         /// <param name="target">The target color.</param>

--- a/Module/src/PSWordCloud/WCUtils.cs
+++ b/Module/src/PSWordCloud/WCUtils.cs
@@ -77,7 +77,7 @@ namespace PSWordCloud
         /// </summary>
         /// <param name="target">The target color.</param>
         /// <param name="backdrop">A reference color to compare against.</param>
-        internal static bool IsDistinctColor(this SKColor target, SKColor backdrop)
+        internal static bool IsDistinctFrom(this SKColor target, SKColor backdrop)
         {
             backdrop.ToHsv(out float refHue, out float refSaturation, out float refBrightness);
             target.ToHsv(out float hue, out float saturation, out float brightness);

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -27,7 +27,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
- -FocusWord <String> [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
+ -FocusWord <String> [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
  [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
  [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
@@ -47,7 +47,7 @@ New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String>
 ```
 New-WordCloud -InputObject <PSObject> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
- [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
+ [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
  [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
@@ -67,7 +67,7 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [
 ```
 New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [-Typeface <SKTypeface>]
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
- -FocusWord <String> [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
+ -FocusWord <String> [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
  [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
  [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
@@ -87,7 +87,7 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String
 ```
 New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
- [-RotateFocusWord <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
+ [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
  [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
  [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
@@ -346,6 +346,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -FocusWordAngle
+
+Specify an angle in degrees to rotate the focus word by, overriding the default random rotations for the focus word only.
+
+Values from -360 to 360, including sub-degree increments, are permitted.
+
+```yaml
+Type: Single
+Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord, ColorBackground-FocusWord-WordTable, FileBackground-FocusWord-WordTable
+Aliases: RotateTitle, RotateFocusWord
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ImageSize
 
 Determines the canvas size for the word cloud image.
@@ -541,24 +559,6 @@ Determines the seed value for the random numbers used to vary the position and p
 Type: Int32
 Parameter Sets: (All)
 Aliases: SeedValue
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RotateFocusWord
-
-Specify an angle in degrees to rotate the focus word by, overriding the default random rotations for the focus word only.
-
-Values from -360 to 360, including sub-degree increments, are permitted.
-
-```yaml
-Type: Single
-Parameter Sets: ColorBackground-FocusWord, FileBackground-FocusWord, ColorBackground-FocusWord-WordTable, FileBackground-FocusWord-WordTable
-Aliases: RotateTitle
 
 Required: False
 Position: Named


### PR DESCRIPTION
# :memo: PR Summary

This PR refactors out significant portions of `EndProcessing()` into helper methods so that the main method is significantly cleaner.

@seeminglyscience if you're wanting some "fun" stuff to look at, I'd appreciate if you have the time to give this a look over & make sure I'm doing the cancellation appropriately, at least. If you wanna take a gander at the rest and make any suggestions that come to mind, you're more than welcome to! 💖 

## :books: Context

`EndProcessing()` was a monster of a method, and debugging anything within it was a bit of a nightmare. Splitting functionality out into helper methods makes it significantly easier to manage. This can be improved upon further, but for now this degree of abstraction is significantly simpler to work with.

Some of the auxiliary files were also refactored to make the code a bit clearer here and there, and a few helper methods were added into the utils class.

## :wrench: Changes

### NewWordCloudCommand

- Renamed consts because ALL_CAPS is a really annoying convention to perpetuate.
- Added cancellation support via `StopProcessing()` and manual handling of the cancellation token in the more bulky parts of the code (during text processing, and during word placement).
- Renamed `-RotateFocusWord` -> `-FocusWordAngle` (leaving old name as alias).
- Added & updated a _ton_ of XML comments for the methods to be as clear as I can on what they all do.
- Renamed some private members to make them more self-explanatory.
- Decimated `EndProcessing()` and pulled out all the major segments of its functionality into helper methods.

### Helper / Miscellaneous

- Added some additional helper and extension methods into `WCUtils` to make code a bit clearer without necessitating long class/method names. 
  - Lookin' at you, `LanguagePrimitives.ConvertTo<T>()`
- Adjusted the `Shuffle<T>` method to:
  - Operate on `IList<T>` rather than `T[]` for flexibility.
  - Return the shuffled list to make some code patterns a bit easier to work with.

## :clipboard: Checklist

+ [x] :warning: Pull Request has a meaningful title.
+ [x] :memo: Filled out the template above.
+ [x] :arrow_forward: Pull Request is ready to merge & is not WIP.
+ [ ] :white_check_mark: **Tests** (select one)
  + [ ] :heavy_plus_sign: Added or updated tests.
  + [ ] :video_game: Only testable interactively.

+ [x] :book: **Documentation** (select one)
  + [x] :page_facing_up: Added documentation.
  + [ ] :bookmark: Created issue to add documentation later:
    + Issue #__
  + [ ] :warning: None required
