### PR TITLE
Major Rework - Placement, sizing, cleanliness, and speed.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "omnisharp.enableRoslynAnalyzers": true,
+    "cSpell.words": [
+        "AARRGGBB",
+        "ARGB",
+        "RRGGBB",
+        "wcloud"
+    ]
+}

--- a/Module/PSWordCloudCmdlet.csproj
+++ b/Module/PSWordCloudCmdlet.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <nullable>enable</nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Module/PSWordCloudCmdlet.csproj
+++ b/Module/PSWordCloudCmdlet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <nullable>enable</nullable>
   </PropertyGroup>
 

--- a/Module/src/PSWordCloud/Attributes.cs
+++ b/Module/src/PSWordCloud/Attributes.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
@@ -40,6 +39,8 @@ namespace PSWordCloud
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
             int sideLength = 0;
+            SKSizeI? result;
+
             switch (inputData)
             {
                 case SKSize sk:
@@ -72,75 +73,42 @@ namespace PSWordCloud
                     {
                         sideLength = (int)ul;
                     }
+
                     break;
                 case decimal d:
                     if (d <= int.MaxValue)
                     {
                         sideLength = (int)Math.Round(d);
                     }
+
                     break;
                 case float f:
                     if (f <= int.MaxValue)
                     {
                         sideLength = (int)Math.Round(f);
                     }
+
                     break;
                 case double d:
                     if (d <= int.MaxValue)
                     {
                         sideLength = (int)Math.Round(d);
                     }
+
                     break;
                 case string s:
-                    if (WCUtils.StandardImageSizes.ContainsKey(s))
+                    result = GetSizeFromString(s);
+                    if (result != null)
                     {
-                        return WCUtils.StandardImageSizes[s].Size;
-                    }
-                    else
-                    {
-                        var matchWH = Regex.Match(s, @"^(?<Width>[\d\.,]+)x(?<Height>[\d\.,]+)(px)?$");
-                        if (matchWH.Success)
-                        {
-                            try
-                            {
-                                var width = int.Parse(matchWH.Groups["Width"].Value);
-                                var height = int.Parse(matchWH.Groups["Height"].Value);
-
-                                return new SKSizeI(width, height);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new ArgumentTransformationMetadataException(
-                                    "Could not parse input string as a float value", e);
-                            }
-                        }
-
-                        var matchSide = Regex.Match(s, @"^(?<SideLength>[\d\.,]+)(px)?$");
-                        if (matchSide.Success)
-                        {
-                            sideLength = int.Parse(matchSide.Groups["SideLength"].Value);
-                        }
+                        return result;
                     }
 
                     break;
                 case object o:
-                    IEnumerable properties;
-                    if (o is Hashtable ht)
+                    result = GetSizeFromProperties(o);
+                    if (result != null)
                     {
-                        properties = ht;
-                    }
-                    else
-                    {
-                        properties = PSObject.AsPSObject(o).Properties;
-                    }
-
-                    if (properties.GetValue("Width") != null && properties.GetValue("Height") != null)
-                    {
-                        // If these conversions fail, the exception will cause the transform to fail.
-                        var width = properties.GetValue("Width").ConvertTo<int>();
-                        var height = properties.GetValue("Height").ConvertTo<int>();
-
-                        return new SKSizeI(width, height);
+                        return result;
                     }
 
                     break;
@@ -153,6 +121,71 @@ namespace PSWordCloud
 
             var errorMessage = $"Unrecognisable input '{inputData}' for SKSize parameter. See the help documentation for the parameter for allowed values.";
             throw new ArgumentTransformationMetadataException(errorMessage);
+        }
+
+        private SKSizeI? GetSizeFromString(string str)
+        {
+            if (WCUtils.StandardImageSizes.ContainsKey(str))
+            {
+                return WCUtils.StandardImageSizes[str].Size;
+            }
+            else
+            {
+                var matchWH = Regex.Match(str, @"^(?<Width>[\d\.,]+)x(?<Height>[\d\.,]+)(px)?$");
+                if (matchWH.Success)
+                {
+                    try
+                    {
+                        var width = int.Parse(matchWH.Groups["Width"].Value);
+                        var height = int.Parse(matchWH.Groups["Height"].Value);
+
+                        return new SKSizeI(width, height);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new ArgumentTransformationMetadataException(
+                            "Could not parse input string as an integer value", e);
+                    }
+                }
+
+                var matchSide = Regex.Match(str, @"^(?<SideLength>[\d\.,]+)(px)?$");
+                if (matchSide.Success)
+                {
+                    var sideLength = int.Parse(matchSide.Groups["SideLength"].Value);
+                    return new SKSizeI(sideLength, sideLength);
+                }
+            }
+
+            return null;
+        }
+
+        private SKSizeI? GetSizeFromProperties(object obj)
+        {
+            IEnumerable properties;
+            if (obj is Hashtable ht)
+            {
+                properties = ht;
+            }
+            else
+            {
+                properties = PSObject.AsPSObject(obj).Properties;
+            }
+
+            if (properties.GetValue("Width") != null && properties.GetValue("Height") != null)
+            {
+                // If these conversions fail, the exception will cause the transform to fail.
+                object? width = properties.GetValue("Width");
+                object? height = properties.GetValue("Height");
+
+                if (width is null || height is null)
+                {
+                    return null;
+                }
+
+                return new SKSizeI(width.ConvertTo<int>(), height.ConvertTo<int>());
+            }
+
+            return null;
         }
     }
 
@@ -214,17 +247,20 @@ namespace PSWordCloud
                 || properties.GetValue("FontSlant") != null
                 || properties.GetValue("FontWidth") != null)
             {
-                SKFontStyleWeight weight = properties.GetValue("FontWeight") == null
+                object? weightValue = properties.GetValue("FontWeight");
+                SKFontStyleWeight weight = weightValue is null
                     ? SKFontStyleWeight.Normal
-                    : properties.GetValue("FontWeight").ConvertTo<SKFontStyleWeight>();
+                    : weightValue.ConvertTo<SKFontStyleWeight>();
 
-                SKFontStyleSlant slant = properties.GetValue("FontSlant") == null
+                object? slantValue = properties.GetValue("FontSlant");
+                SKFontStyleSlant slant = slantValue is null
                     ? SKFontStyleSlant.Upright
-                    : properties.GetValue("FontSlant").ConvertTo<SKFontStyleSlant>();
+                    : slantValue.ConvertTo<SKFontStyleSlant>();
 
-                SKFontStyleWidth width = properties.GetValue("FontWidth") == null
+                object? widthValue = properties.GetValue("FontWidth");
+                SKFontStyleWidth width = widthValue is null
                     ? SKFontStyleWidth.Normal
-                    : properties.GetValue("FontWidth").ConvertTo<SKFontStyleWidth>();
+                    : widthValue.ConvertTo<SKFontStyleWidth>();
 
                 style = new SKFontStyle(weight, width, slant);
             }
@@ -235,7 +271,7 @@ namespace PSWordCloud
                     : SKFontStyle.Normal;
             }
 
-            string familyName = properties.GetValue("FamilyName").ConvertTo<string>();
+            string familyName = properties.GetValue("FamilyName")?.ConvertTo<string>() ?? string.Empty;
             return WCUtils.FontManager.MatchFamily(familyName, style);
         }
 
@@ -301,21 +337,25 @@ namespace PSWordCloud
                     properties = PSObject.AsPSObject(item).Properties;
                 }
 
-                byte red = properties.GetValue("red") == null
+                object? redValue = properties.GetValue("red");
+                byte red = redValue is null
                     ? (byte)0
-                    : properties.GetValue("red").ConvertTo<byte>();
+                    : redValue.ConvertTo<byte>();
 
-                byte green = properties.GetValue("green") == null
+                object? greenValue = properties.GetValue("green");
+                byte green = greenValue is null
                     ? (byte)0
-                    : properties.GetValue("green").ConvertTo<byte>();
+                    : greenValue.ConvertTo<byte>();
 
-                byte blue = properties.GetValue("blue") == null
+                object? blueValue = properties.GetValue("blue");
+                byte blue = blueValue is null
                     ? (byte)0
-                    : properties.GetValue("blue").ConvertTo<byte>();
+                    : blueValue.ConvertTo<byte>();
 
-                byte alpha = properties.GetValue("alpha") == null
+                object? alphaValue = properties.GetValue("alpha");
+                byte alpha = alphaValue is null
                     ? (byte)255
-                    : properties.GetValue("alpha").ConvertTo<byte>();
+                    : alphaValue.ConvertTo<byte>();
 
                 colorList.Add(new SKColor(red, green, blue, alpha));
             }

--- a/Module/src/PSWordCloud/Attributes.cs
+++ b/Module/src/PSWordCloud/Attributes.cs
@@ -98,7 +98,7 @@ namespace PSWordCloud
                     break;
                 case string s:
                     result = GetSizeFromString(s);
-                    if (result != null)
+                    if (result is not null)
                     {
                         return result;
                     }
@@ -106,7 +106,7 @@ namespace PSWordCloud
                     break;
                 case object o:
                     result = GetSizeFromProperties(o);
-                    if (result != null)
+                    if (result is not null)
                     {
                         return result;
                     }
@@ -171,7 +171,7 @@ namespace PSWordCloud
                 properties = PSObject.AsPSObject(obj).Properties;
             }
 
-            if (properties.GetValue("Width") != null && properties.GetValue("Height") != null)
+            if (properties.GetValue("Width") is not null && properties.GetValue("Height") is not null)
             {
                 // If these conversions fail, the exception will cause the transform to fail.
                 object? width = properties.GetValue("Width");
@@ -243,9 +243,9 @@ namespace PSWordCloud
             }
 
             SKFontStyle style;
-            if (properties.GetValue("FontWeight") != null
-                || properties.GetValue("FontSlant") != null
-                || properties.GetValue("FontWidth") != null)
+            if (properties.GetValue("FontWeight") is not null
+                || properties.GetValue("FontSlant") is not null
+                || properties.GetValue("FontWidth") is not null)
             {
                 object? weightValue = properties.GetValue("FontWeight");
                 SKFontStyleWeight weight = weightValue is null

--- a/Module/src/PSWordCloud/Constants.cs
+++ b/Module/src/PSWordCloud/Constants.cs
@@ -1,0 +1,14 @@
+namespace PSWordCloud
+{
+    internal static class Constants
+    {
+        internal const float BaseAngularIncrement = 360 / 7;
+        internal const float BleedAreaScale = 1.5f;
+        internal const float FocusWordScale = 1.15f;
+        internal const float MaxWordAreaPercent = 0.9f;
+        internal const float MaxWordWidthPercent = 0.95f;
+        internal const int MinEffectiveWordWidth = 15;
+        internal const float PaddingBaseScale = 1.5f;
+        internal const float StrokeBaseScale = 0.01f;
+    }
+}

--- a/Module/src/PSWordCloud/Extensions.cs
+++ b/Module/src/PSWordCloud/Extensions.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+using System.Xml;
+using SkiaSharp;
+
+namespace PSWordCloud
+{
+    internal static class Extensions
+    {
+        internal static SKPoint Multiply(this SKPoint point, float factor)
+            => new SKPoint(point.X * factor, point.Y * factor);
+
+        internal static float ToRadians(this float degrees)
+            => (float)(degrees * Math.PI / 180);
+
+        /// <summary>
+        /// Utility method which is just a convenient shortcut to <see cref="LanguagePrimitives.ConvertTo{T}(object)"/>.
+        /// </summary>
+        /// <param name="item">The object to convert.</param>
+        /// <typeparam name="TSource">The original object type.</typeparam>
+        /// <typeparam name="TResult">The resulting destination type.</typeparam>
+        /// <returns>The converted value.</returns>
+        public static TResult ConvertTo<TResult>(this object item)
+            => LanguagePrimitives.ConvertTo<TResult>(item);
+
+        /// <summary>
+        /// Perform an in-place-modification operation on every element in the array.
+        /// </summary>
+        /// <param name="items">The array to operate on.</param>
+        /// <returns>The transformed array.</returns>
+        public static T[] TransformElements<T>(this T[] items, Func<T, T> operation)
+        {
+            for (var index = 0; index < items.Length; index++)
+            {
+                items[index] = operation.Invoke(items[index]);
+            }
+
+            return items;
+        }
+
+        public static SKColor AsMonochrome(this SKColor color)
+        {
+            color.ToHsv(out _, out _, out float brightness);
+            byte level = (byte)Math.Floor(255 * brightness / 100f);
+
+            return new SKColor(level, level, level);
+        }
+
+        /// <summary>
+        /// Determines whether a given color is considered sufficiently visually distinct from a backdrop color.
+        /// </summary>
+        /// <param name="target">The target color.</param>
+        /// <param name="backdrop">A reference color to compare against.</param>
+        internal static bool IsDistinctFrom(this SKColor target, SKColor backdrop)
+        {
+            if (target.IsTransparent())
+            {
+                return false;
+            }
+
+            backdrop.ToHsv(out float refHue, out float refSaturation, out float refBrightness);
+            target.ToHsv(out float hue, out float saturation, out float brightness);
+
+            float brightnessDistance = Math.Abs(refBrightness - brightness);
+            if (brightnessDistance > 30)
+            {
+                return true;
+            }
+
+            float hueDistance = Math.Abs(refHue - hue);
+            if (hueDistance > 24 && brightnessDistance > 20)
+            {
+                return true;
+            }
+
+            float saturationDistance = Math.Abs(refSaturation - saturation);
+            return saturationDistance > 24 && brightnessDistance > 18;
+        }
+
+        private static bool IsTransparent(this SKColor color) => color.Alpha == 0;
+
+        /// <summary>
+        /// Gets the smallest square that would completely contain the given <paramref name="rectangle"/>, with the rectangle positioned
+        /// at its centre.
+        /// </summary>
+        /// <param name="rectangle">The rectangle to find the containing square for.</param>
+        internal static SKRect GetEnclosingSquare(this SKRect rectangle)
+            => rectangle switch
+            {
+                SKRect wide when wide.Width > wide.Height => SKRect.Inflate(wide, x: 0, y: (wide.Width - wide.Height) / 2),
+                SKRect tall when tall.Height > tall.Width => SKRect.Inflate(tall, x: (tall.Height - tall.Width) / 2, y: 0),
+                _ => SKRect.Inflate(rectangle, x: 0, y: 0)
+            };
+
+        /// <summary>
+        /// Returns a random <see cref="float"/> value between the specified minimum and maximum.
+        /// </summary>
+        /// <param name="random">The <see cref="Random"/> instance to use for the generation.</param>
+        /// <param name="min">The minimum float value.</param>
+        /// <param name="max">The maximum float value.</param>
+        internal static float NextFloat(this Random random, float min, float max)
+        {
+            if (min > max)
+            {
+                return max;
+            }
+
+            var range = max - min;
+            return (float)random.NextDouble() * range + min;
+        }
+
+        /// <summary>
+        /// Performs an in-place random shuffle on an array by swapping elements.
+        /// This algorithm is pretty commonly used, but effective and fast enough for our purposes.
+        /// </summary>
+        /// <param name="rng">Random number generator.</param>
+        /// <param name="array">The array to shuffle.</param>
+        /// <typeparam name="T">The element type of the array.</typeparam>
+        internal static IList<T> Shuffle<T>(this Random rng, IList<T> array)
+        {
+            int n = array.Count;
+            while (n > 1)
+            {
+                int k = rng.Next(n--);
+                T temp = array[n];
+                array[n] = array[k];
+                array[k] = temp;
+            }
+
+            return array;
+        }
+
+        /// <summary>
+        /// Checks if any part of the rectangle lies outside the region's bounds.
+        /// </summary>
+        /// <param name="rectangle">The rectangle to test position against the edges of the region.</param>
+        /// <param name="region">The region to test against.</param>
+        /// <returns>Returns false if the rectangle is entirely within the region, and false otherwise.</returns>
+        internal static bool FallsOutside(this SKRect rectangle, SKRegion region)
+        {
+            var bounds = region.Bounds;
+            return rectangle.Top < bounds.Top
+                || rectangle.Bottom > bounds.Bottom
+                || rectangle.Left < bounds.Left
+                || rectangle.Right > bounds.Right;
+        }
+
+        /// <summary>
+        /// Checks if the given point is outside the given <see cref="SKRegion"/>.
+        /// </summary>
+        /// <param name="point">The point in question.</param>
+        /// <param name="region">The region to check against.</param>
+        /// <returns>Returns true if the point is within the given region.</returns>
+        internal static bool IsOutside(this SKPoint point, SKRegion region) => !region.Contains(point);
+
+        /// <summary>
+        /// Translates the <see cref="SKPath"/> so that its midpoint is the given position.
+        /// </summary>
+        /// <param name="path">The path to translate.</param>
+        /// <param name="point">The new point to centre the path on.</param>
+        internal static void CentreOnPoint(this SKPath path, SKPoint point)
+        {
+            var pathMidpoint = new SKPoint(path.TightBounds.MidX, path.TightBounds.MidY);
+            path.Offset(point - pathMidpoint);
+        }
+
+        /// <summary>
+        /// Checks if the given <paramref name="point"/> lies somewhere inside the <paramref name="region"/>.
+        /// </summary>
+        /// <param name="region">The region that defines the bounds.</param>
+        /// <param name="point">The point to check.</param>
+        /// <returns></returns>
+        internal static bool Contains(this SKRegion region, SKPoint point)
+        {
+            SKRectI bounds = region.Bounds;
+            return bounds.Left < point.X && point.X < bounds.Right
+                && bounds.Top < point.Y && point.Y < bounds.Bottom;
+        }
+
+        internal static void SetFill(this SKPaint brush, SKColor fill)
+        {
+            brush.IsStroke = false;
+            brush.Style = SKPaintStyle.Fill;
+            brush.Color = fill;
+        }
+
+        internal static void SetStroke(this SKPaint brush, SKColor stroke, float width)
+        {
+            brush.IsStroke = true;
+            brush.StrokeWidth = width;
+            brush.Style = SKPaintStyle.Stroke;
+            brush.Color = stroke;
+        }
+
+        /// <summary>
+        /// Sets the contents of the region to the specified path.
+        /// </summary>
+        /// <param name="region">The region to set the path into.</param>
+        /// <param name="path">The path object.</param>
+        /// <param name="usePathBounds">Whether to set the region's new bounds to the bounds of the path itself.</param>
+        internal static bool SetPath(this SKRegion region, SKPath path, bool usePathBounds)
+        {
+            if (usePathBounds && path.GetBounds(out SKRect bounds))
+            {
+                using SKRegion clip = new SKRegion();
+
+                clip.SetRect(SKRectI.Ceiling(bounds));
+                return region.SetPath(path, clip);
+            }
+            else
+            {
+                return region.SetPath(path);
+            }
+        }
+
+        /// <summary>
+        /// Combines the region with a given path, specifying the operation used to combine.
+        /// </summary>
+        /// <param name="region">The region to perform the operation on.</param>
+        /// <param name="path">The path to perform the operation with.</param>
+        /// <param name="operation">The type of operation to perform.</param>
+        /// <returns></returns>
+        internal static bool CombineWithPath(this SKRegion region, SKPath path, SKRegionOperation operation)
+        {
+            using SKRegion pathRegion = new SKRegion();
+
+            pathRegion.SetPath(path, usePathBounds: true);
+            return region.Op(pathRegion, operation);
+        }
+
+        /// <summary>
+        /// Rotates the given path by the declared angle.
+        /// </summary>
+        /// <param name="path">The path to rotate.</param>
+        /// <param name="degrees">The angle in degrees to rotate the path.</param>
+        internal static void Rotate(this SKPath path, float degrees)
+        {
+            SKRect pathBounds = path.TightBounds;
+            SKMatrix rotation = SKMatrix.CreateRotationDegrees(degrees, pathBounds.MidX, pathBounds.MidY);
+            path.Transform(rotation);
+        }
+
+        /// <summary>
+        /// Checks whether the region intersects the given rectangle.
+        /// </summary>
+        /// <param name="region">The region to check collision with.</param>
+        /// <param name="rect">The rectangle to check for intersection.</param>
+        internal static bool IntersectsRect(this SKRegion region, SKRect rect)
+        {
+            if (region.Bounds.IsEmpty)
+            {
+                return false;
+            }
+
+            using SKRegion rectRegion = new SKRegion();
+
+            rectRegion.SetRect(SKRectI.Round(rect));
+            return region.Intersects(rectRegion);
+        }
+
+        /// <summary>
+        /// Checks whether the region intersects the given path.
+        /// </summary>
+        /// <param name="region">The region to check collision with.</param>
+        /// <param name="rect">The rectangle to check for intersection.</param>
+        internal static bool IntersectsPath(this SKRegion region, SKPath path)
+        {
+            if (region.Bounds.IsEmpty)
+            {
+                return false;
+            }
+
+            using SKRegion pathRegion = new SKRegion();
+
+            pathRegion.SetPath(path, region);
+            return region.Intersects(pathRegion);
+        }
+
+        internal static string GetPrettyString(this XmlDocument document)
+        {
+            var stringBuilder = new StringBuilder();
+
+            var settings = new XmlWriterSettings
+            {
+                Indent = true
+            };
+
+            using (var xmlWriter = XmlWriter.Create(stringBuilder, settings))
+            {
+                document.Save(xmlWriter);
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        internal static object? GetValue(this IEnumerable collection, string key)
+            => collection switch
+            {
+                PSMemberInfoCollection<PSPropertyInfo> properties => properties[key].Value,
+                IDictionary dictionary => dictionary[key],
+                IDictionary<string, dynamic> dictT => dictT[key],
+                _ => throw new ArgumentException(
+                    string.Format(
+                    "GetValue method only accepts {0} or {1}",
+                    typeof(PSMemberInfoCollection<PSPropertyInfo>).ToString(),
+                    typeof(IDictionary).ToString())),
+            };
+
+    }
+}

--- a/Module/src/PSWordCloud/LockingRandom.cs
+++ b/Module/src/PSWordCloud/LockingRandom.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace PSWordCloud
+{
+    class LockingRandom
+    {
+        private const int MinimumAngleCount = 4;
+        private const int MaximumAngleCount = 14;
+
+        private readonly Random _random;
+        private readonly object _lock = new object();
+
+        internal LockingRandom()
+        {
+            _random = new Random();
+        }
+
+        internal LockingRandom(int seed)
+        {
+            _random = new Random(seed);
+        }
+
+        internal float PickRandomQuadrant()
+            => GetRandomInt(0, 4) * 90;
+
+        internal float RandomFloat()
+        {
+            lock (_lock)
+            {
+                return (float)_random.NextDouble();
+            }
+        }
+
+        internal float RandomFloat(float min, float max)
+        {
+            lock (_lock)
+            {
+                return _random.NextFloat(min, max);
+            }
+        }
+
+        internal int GetRandomInt()
+        {
+            lock (_lock)
+            {
+                return _random.Next();
+            }
+        }
+
+        internal int GetRandomInt(int min, int max)
+        {
+            lock (_lock)
+            {
+                return _random.Next(min, max);
+            }
+        }
+
+        internal IList<T> Shuffle<T>(IList<T> items)
+        {
+            lock (_lock)
+            {
+                return _random.Shuffle(items);
+            }
+        }
+
+        internal IList<float> GetRandomFloats(
+            int min,
+            int max,
+            int minCount = MinimumAngleCount,
+            int maxCount = MaximumAngleCount)
+        {
+            var angles = new float[GetRandomInt(minCount, maxCount)];
+            for (var index = 0; index < angles.Length; index++)
+            {
+                angles[index] = RandomFloat(min, max);
+            }
+
+            return angles;
+        }
+    }
+}

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -60,7 +60,7 @@ namespace PSWordCloud
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = COLOR_BG_FOCUS_SET)]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = FILE_SET)]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = FILE_FOCUS_SET)]
-        [Alias("InputString", "Text", "String", "Words", "Document", "Page")]
+        [Alias("InputString", "Text", "String", "Document", "Page")]
         [AllowEmptyString()]
         public PSObject? InputObject { get; set; }
 

--- a/Module/src/PSWordCloud/Word.cs
+++ b/Module/src/PSWordCloud/Word.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace PSWordCloud
+{
+    internal class Word
+    {
+        internal Word(string text, float relativeSize)
+        {
+            Text = text;
+            RelativeSize = relativeSize;
+        }
+
+        internal string Text { get; set; }
+
+        internal float RelativeSize { get; set; }
+
+        internal float ScaledSize { get; private set; }
+
+        /// <summary>
+        /// Scale the <see cref="Word"/> by the global scale value and determine its final size.
+        /// </summary>
+        /// <param name="baseSize">The base size for the font.</param>
+        /// <param name="globalScale">The global scaling factor.</param>
+        /// <param name="allWords">The dictionary of word scales containing their base sizes.</param>
+        /// <returns>The scaled word size.</returns>
+        internal float Scale(float globalScale)
+        {
+            ScaledSize = RelativeSize * globalScale;
+            return ScaledSize;
+        }
+
+        public override string ToString() => Text;
+    }
+}

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -59,8 +59,8 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>]
  [-Padding <Single>] [-WordBubble <WordBubbleShape>] [-DistanceStep <Single>] [-RadialStep <Single>]
- [-MaxRenderedWords <Int32>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords]
- [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru]
+ [<CommonParameters>]
 ```
 
 ### ColorBackground-FocusWord-WordTable
@@ -69,8 +69,8 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [
  [-BackgroundColor <SKColor>] [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>]
  -FocusWord <String> [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>]
  [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
- [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome]
+ [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ### FileBackground-WordTable
@@ -78,9 +78,8 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> [-ImageSize <SKSizeI>] [
 New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String> [-Typeface <SKTypeface>]
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] [-ExcludeWord <String[]>]
  [-IncludeWord <String[]>] [-WordScale <Single>] [-AllowRotation <WordOrientations>] [-Padding <Single>]
- [-WordBubble <WordBubbleShape>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>]
- [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru]
- [<CommonParameters>]
+ [-WordBubble <WordBubbleShape>] [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxColors <Int32>]
+ [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ### FileBackground-FocusWord-WordTable
@@ -89,8 +88,8 @@ New-WordCloud -WordSizes <IDictionary> [-Path] <String> -BackgroundImage <String
  [-ColorSet <SKColor[]>] [-StrokeWidth <Single>] [-StrokeColor <SKColor>] -FocusWord <String>
  [-FocusWordAngle <Single>] [-ExcludeWord <String[]>] [-IncludeWord <String[]>] [-WordScale <Single>]
  [-AllowRotation <WordOrientations>] [-Padding <Single>] [-WordBubble <WordBubbleShape>]
- [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxRenderedWords <Int32>] [-MaxColors <Int32>]
- [-RandomSeed <Int32>] [-Monochrome] [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
+ [-DistanceStep <Single>] [-RadialStep <Single>] [-MaxColors <Int32>] [-RandomSeed <Int32>] [-Monochrome]
+ [-AllowStopWords] [-AllowOverflow] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -290,7 +289,7 @@ Required: False
 Position: Named
 Default value: *
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -DistanceStep
@@ -458,7 +457,7 @@ However, an appropriate vector graphics viewer or editor is still capable of zoo
 
 ```yaml
 Type: Int32
-Parameter Sets: (All)
+Parameter Sets: ColorBackground, ColorBackground-FocusWord, FileBackground, FileBackground-FocusWord
 Aliases: MaxWords
 
 Required: False


### PR DESCRIPTION
# :memo: PR Summary

Project was getting a bit bloated and hard to maintain or make modifications to. This is a **major** rework of just about everything, isolating logic branches into separate methods, etc.

Multiple classes were added to simplify handling of data and keep helper methods out of the main cmdlet class as much as possible. Nullability annotations were also enabled and are in full use throughout the project (Roslyn analyzer ftw 💖).

While this is largely a major improvement across the board, there are a lot of changes, and it's possible I've managed to break something that works in a previous version. In particular, the standard scaling does a great job of making sure a good amount of the image canvas is covered by default now; as a result, older usages that perhaps had a higher `-WordScale` value will now start overscaling things quite a bit, so those usages will need to lower their custom `-WordScale` amounts to make things work.

However, the cmdlet is now _much_ better at appropriately scaling clouds that have a great many words all of fairly similar sizes.

## :wrench: Changes

- Enabled nullability annotations and resolved Roslyn analyzer issues that appeared on doing so.
- Reworked placement algorithms and padding calculations.
- Reworked size estimation algorithms to be much more accurate, which makes scaling estimates much more appropriate for the image size and dimensions.
- Constrain maximum word widths based on a minimum word length so small words don't scale out of control and require several re-calcs to make things fit.
- Changed the concurrency behaviour away from using async/await since we need to wait on the main thread all the time anyway.
- :fire: **Removed** parameter alias `-Words` which was for `-InputObject`; this name is too similar to `-WordSizes` which is the name for the alternate input method, so this confused _me_ for a bit. Best to remove it.

Also, split several things out into separate classes:

- Constants.cs - hold constants used for calculations.
- Extensions.cs - holds extension methods instead of WCUtils.
- LockingRandom.cs - class-based implementation of the threadsafe Random logic that was already being used.
- Word.cs - created a new type to simplify handling of words and sizes.

<details>
    <summary><strong>Samples</strong></summary>

![Sonnet. Written On A Blank Space At The End Of Chaucer's Tale Of 'The Floure And The Lefe'](https://gist.github.com/vexx32/7529e81198f581f007ea43d53d851443/raw/26625f9e2b474110d55310ec5fd1435142feec9a/Sonnet.%2520Written%2520On%2520A%2520Blank%2520Space%2520At%2520The%2520End%2520Of%2520Chaucer's%2520Tale%2520Of%2520'The%2520Floure%2520And%2520The%2520Lefe'.svg)

![I Am Taliesin. I Sing Perfect Metre](https://gist.github.com/vexx32/937f354c7124d809a9b5e31c3a7e57c9/raw/cbe7062890751fd7d70dd53c736a008c95beb376/I%2520Am%2520Taliesin.%2520I%2520Sing%2520Perfect%2520Metre.svg)

</details>

## :clipboard: Checklist

+ [x] :warning: Pull Request has a meaningful title.
+ [x] :memo: Filled out the template above.
+ [x] :arrow_forward: Pull Request is ready to merge & is not WIP.
+ [x] :white_check_mark: **Tests** (select one)
  + [ ] :heavy_plus_sign: Added or updated tests.
  + [x] :video_game: Only testable interactively.

+ [ ] :book: **Documentation** (select one)
  + [ ] :page_facing_up: Added documentation.
  + [ ] :bookmark: Created issue to add documentation later:
    + Issue #__
  + [ ] :warning: None required
