### PR TITLE
(#84) Write explicit error on empty input

### DIFF
--- a/Module/src/PSWordCloud/ErrorCodes.cs
+++ b/Module/src/PSWordCloud/ErrorCodes.cs
@@ -1,0 +1,7 @@
+namespace PSWordCloud
+{
+    internal static class ErrorCodes
+    {
+        internal const string NoUsableInput = "PSWordCloud.NoUsableInput";
+    }
+}

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -710,6 +710,17 @@ namespace PSWordCloud
         private IReadOnlyList<Word> GetFinalWordList(SKRectI drawableBounds, SKRect viewbox)
         {
             IReadOnlyList<Word> wordList = GetRelativeWordSizes(ParameterSetName);
+            if (wordList.Count == 0)
+            {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new ArgumentException("No usable input was provided. Please provide string data via the pipeline or in a word size dictionary."),
+                        ErrorCodes.NoUsableInput,
+                        ErrorCategory.InvalidData,
+                        MyInvocation.BoundParameters.ContainsKey(nameof(InputObject))
+                            ? InputObject
+                            : WordSizes));
+            }
 
             (float averageWordFrequency, float averageWordLength) = GetWordListStatistics(wordList);
 

--- a/Module/src/PSWordCloud/NewWordCloudCommand.cs
+++ b/Module/src/PSWordCloud/NewWordCloudCommand.cs
@@ -718,7 +718,7 @@ namespace PSWordCloud
                         ErrorCodes.NoUsableInput,
                         ErrorCategory.InvalidData,
                         MyInvocation.BoundParameters.ContainsKey(nameof(InputObject))
-                            ? InputObject
+                            ? InputObject?.BaseObject
                             : WordSizes));
             }
 

--- a/Tests/PSWordCloud.Tests.ps1
+++ b/Tests/PSWordCloud.Tests.ps1
@@ -12,6 +12,10 @@ Describe 'PSWordCloud Tests' {
         { Import-Module PSWordCloud -ErrorAction Stop } | Should -Not -Throw
     }
 
+    It 'should error out for empty or otherwise unusable input' {
+        { [string]::Empty | New-WordCloud -Path ./test.svg } | Should -Throw -ExpectedMessage "No usable input was provided. Please provide string data via the pipeline or in a word size dictionary."
+    }
+
     Context 'FileSystem Provider' {
         It 'should run New-WordCloud without errors' {
             Get-ChildItem -Path "$PSScriptRoot/../" -Recurse -File -Include "*.cs", "*.ps*1", "*.md" |

--- a/docs/New-WordCloud.md
+++ b/docs/New-WordCloud.md
@@ -421,7 +421,7 @@ If you are entering complex object input, ensure the objects have a meaningful T
 ```yaml
 Type: PSObject
 Parameter Sets: ColorBackground, ColorBackground-FocusWord, FileBackground, FileBackground-FocusWord
-Aliases: InputString, Text, String, Words, Document, Page
+Aliases: InputString, Text, String, Document, Page
 
 Required: True
 Position: Named


### PR DESCRIPTION
# :memo: PR Summary

Added an explicit error message for unusable / no input provided.

## :books: Context

Empty input can just be no input given, or it can also be that the provided input cannot be converted to usable strings. Best to write a coherent error early rather than get an index exception further on and confuse the user.

Resolves #84

## :wrench: Changes

- Throw an error if the input given results in an empty list, immediately after retrieving the final list.

## :clipboard: Checklist

+ [x] :warning: Pull Request has a meaningful title.
+ [x] :memo: Filled out the template above.
+ [x] :arrow_forward: Pull Request is ready to merge & is not WIP.
+ [x] :white_check_mark: **Tests** (select one)
  + [x] :heavy_plus_sign: Added or updated tests.
  + [ ] :video_game: Only testable interactively.

+ [x] :book: **Documentation** (select one)
  + [ ] :page_facing_up: Added documentation.
  + [ ] :bookmark: Created issue to add documentation later:
    + Issue #__
  + [x] :warning: None required
